### PR TITLE
change the name 'properties' to 'superProperties' in init

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,6 @@ rootProject.allprojects {
     repositories {
         google()
         mavenCentral()
-
     }
 }
 

--- a/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
+++ b/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
@@ -188,11 +188,18 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
         mixpanelProperties = new JSONObject(mixpanelPropertiesMap == null ? EMPTY_HASHMAP : mixpanelPropertiesMap);
         Map<String, Object> superPropertiesMap = call.<HashMap<String, Object>>argument("superProperties");
         JSONObject superProperties = new JSONObject(superPropertiesMap == null ? EMPTY_HASHMAP : superPropertiesMap);
+        JSONObject superAndMixpanelProperties;
+        try {
+            superAndMixpanelProperties = MixpanelFlutterHelper.getMergedProperties(superProperties, mixpanelProperties);
+        } catch (JSONException e) {
+            result.error("MixpanelFlutterException", e.getLocalizedMessage(), null);
+            return;
+        }
         if (call.hasArgument("optOutTrackingDefault")) {
             Boolean optOutTrackingDefault = call.<Boolean>argument("optOutTrackingDefault");
-            mixpanel = MixpanelAPI.getInstance(context, token, optOutTrackingDefault == null ? false : optOutTrackingDefault, superProperties);
+            mixpanel = MixpanelAPI.getInstance(context, token, optOutTrackingDefault == null ? false : optOutTrackingDefault, superAndMixpanelProperties);
         } else {
-            mixpanel = MixpanelAPI.getInstance(context, token, false, superProperties);
+            mixpanel = MixpanelAPI.getInstance(context, token, false, superAndMixpanelProperties);
         }
         result.success(Integer.toString(mixpanel.hashCode()));
     }

--- a/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
+++ b/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
@@ -184,15 +184,15 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
         if (token == null) {
             throw new RuntimeException("Your Mixpanel Token was not set");
         }
-        Map<String, Object> mixPanelproperties = call.<HashMap<String, Object>>argument("mixpanelProperties");
-        mixpanelProperties = new JSONObject(mixPanelproperties == null ? EMPTY_HASHMAP : mixPanelproperties);
-        Map<String, Object> argProperties = call.<HashMap<String, Object>>argument("properties");
-        JSONObject properties = new JSONObject(argProperties == null ? EMPTY_HASHMAP : argProperties);
+        Map<String, Object> mixpanelPropertiesMap = call.<HashMap<String, Object>>argument("mixpanelProperties");
+        mixpanelProperties = new JSONObject(mixpanelPropertiesMap == null ? EMPTY_HASHMAP : mixpanelPropertiesMap);
+        Map<String, Object> superPropertiesMap = call.<HashMap<String, Object>>argument("superProperties");
+        JSONObject superProperties = new JSONObject(superPropertiesMap == null ? EMPTY_HASHMAP : superPropertiesMap);
         if (call.hasArgument("optOutTrackingDefault")) {
             Boolean optOutTrackingDefault = call.<Boolean>argument("optOutTrackingDefault");
-            mixpanel = MixpanelAPI.getInstance(context, token, optOutTrackingDefault == null ? false : optOutTrackingDefault, properties);
+            mixpanel = MixpanelAPI.getInstance(context, token, optOutTrackingDefault == null ? false : optOutTrackingDefault, superProperties);
         } else {
-            mixpanel = MixpanelAPI.getInstance(context, token, false, properties);
+            mixpanel = MixpanelAPI.getInstance(context, token, false, superProperties);
         }
         result.success(Integer.toString(mixpanel.hashCode()));
     }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,6 +26,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 29
+    ndkVersion "21.4.7075529"
 
     lintOptions {
         disable 'InvalidPackage'

--- a/lib/mixpanel_flutter.dart
+++ b/lib/mixpanel_flutter.dart
@@ -24,13 +24,14 @@ class Mixpanel {
   ///  * [token] your project token.
   ///  * [optOutTrackingDefault] Optional Whether or not Mixpanel can start tracking by default. See
   ///  optOutTracking()
+  ///  * [superProperties] Optional super properties to register
   ///
   static Future<Mixpanel> init(String token,
-      {bool optOutTrackingDefault = false, Map<String, dynamic>? properties}) async {
+      {bool optOutTrackingDefault = false, Map<String, dynamic>? superProperties}) async {
     var allProperties = <String, dynamic>{'token': token};
     allProperties['optOutTrackingDefault'] = optOutTrackingDefault;
     allProperties['mixpanelProperties'] = _mixpanelProperties;
-    allProperties['properties'] = properties;
+    allProperties['superProperties'] = superProperties;
     await _channel.invokeMethod<void>('initialize', allProperties);
     return Mixpanel(token);
   }

--- a/test/mixpanel_flutter_test.dart
+++ b/test/mixpanel_flutter_test.dart
@@ -38,6 +38,7 @@ void main() {
               '\$lib_version': '1.2.1',
               'mp_lib': 'flutter',
             },
+            'superProperties': null,
           },
         ),
       );
@@ -57,6 +58,7 @@ void main() {
               '\$lib_version': '1.2.1',
               'mp_lib': 'flutter',
             },
+            'superProperties': null,
           },
         ),
       );


### PR DESCRIPTION
A small enhancement to #14. TLDR, change the param name to `superProperties`, and not only super properties but also lib property will be displayed correctly(as `flutter`) in `First App Open`.