### PR TITLE
Fix backward ordering of 'alias()' parameters on Android.

### DIFF
--- a/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
+++ b/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
@@ -246,7 +246,7 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
     private void handleAlias(MethodCall call, Result result) {
         String distinctId = call.argument("distinctId");
         String alias = call.argument("alias");
-        mixpanel.alias(distinctId, alias);
+        mixpanel.alias(alias, distinctId);
         result.success(null);
     }
 


### PR DESCRIPTION
Fixes #57.