### PR TITLE
fix: Make `flush` method asynchronous

### DIFF
--- a/lib/mixpanel_flutter.dart
+++ b/lib/mixpanel_flutter.dart
@@ -406,8 +406,8 @@ class Mixpanel {
   /// are sent to Mixpanel when your application is shut down, you will
   /// need to call flush() to let the Mixpanel library know it should
   /// send all remaining messages to the server.
-  void flush() {
-    _channel.invokeMethod('flush');
+  Future<void> flush() async {
+    await _channel.invokeMethod('flush');
   }
 }
 


### PR DESCRIPTION
Motivation: The documentation advises calling `flush` before `optOutTracking`. And the use case I have in hand is that I want to track a custom event `optOut` when the user opts out of tracking.

Problem: The problem right now is that `flush` and `optOutTracking` are sync, and the invocation to native methods is async, this results in situations where `optOutTracking` native method is completed before `flush` native method. This will prevent `optOut` event from being sent to the dashboard.

Solution: The solution is to make `flush` method asynchronous, and allow the developer to await for it to complete before calling `optOutTracking`.

```
void optOut() async {
track('optOut');
await flush();
optOutTracking();
}
```