### PR TITLE
feat: support `DateTime` and `Uri`

### DIFF
--- a/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
+++ b/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
@@ -4,15 +4,15 @@ import androidx.annotation.NonNull;
 
 import android.content.Context;
 
+import io.flutter.plugin.common.StandardMethodCodec;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.MethodCall;
@@ -42,10 +42,10 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
         this.context = context;
     }
 
-
     @Override
     public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
-        channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "mixpanel_flutter");
+        channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "mixpanel_flutter",
+                new StandardMethodCodec(new MixpanelMessageCodec()));
         context = flutterPluginBinding.getApplicationContext();
         channel.setMethodCallHandler(this);
     }
@@ -184,20 +184,27 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
         if (token == null) {
             throw new RuntimeException("Your Mixpanel Token was not set");
         }
-        Map<String, Object> mixpanelPropertiesMap = call.<HashMap<String, Object>>argument("mixpanelProperties");
-        mixpanelProperties = new JSONObject(mixpanelPropertiesMap == null ? EMPTY_HASHMAP : mixpanelPropertiesMap);
-        Map<String, Object> superPropertiesMap = call.<HashMap<String, Object>>argument("superProperties");
-        JSONObject superProperties = new JSONObject(superPropertiesMap == null ? EMPTY_HASHMAP : superPropertiesMap);
+        Map<String, Object> mixpanelPropertiesMap =
+                call.<HashMap<String, Object>>argument("mixpanelProperties");
+        mixpanelProperties =
+                new JSONObject(mixpanelPropertiesMap == null ? EMPTY_HASHMAP : mixpanelPropertiesMap);
+        Map<String, Object> superPropertiesMap =
+                call.<HashMap<String, Object>>argument("superProperties");
+        JSONObject superProperties =
+                new JSONObject(superPropertiesMap == null ? EMPTY_HASHMAP : superPropertiesMap);
         JSONObject superAndMixpanelProperties;
         try {
-            superAndMixpanelProperties = MixpanelFlutterHelper.getMergedProperties(superProperties, mixpanelProperties);
+            superAndMixpanelProperties =
+                    MixpanelFlutterHelper.getMergedProperties(superProperties, mixpanelProperties);
         } catch (JSONException e) {
             result.error("MixpanelFlutterException", e.getLocalizedMessage(), null);
             return;
         }
         if (call.hasArgument("optOutTrackingDefault")) {
             Boolean optOutTrackingDefault = call.<Boolean>argument("optOutTrackingDefault");
-            mixpanel = MixpanelAPI.getInstance(context, token, optOutTrackingDefault == null ? false : optOutTrackingDefault, superAndMixpanelProperties);
+            mixpanel = MixpanelAPI.getInstance(context, token,
+                    optOutTrackingDefault == null ? false : optOutTrackingDefault,
+                    superAndMixpanelProperties);
         } else {
             mixpanel = MixpanelAPI.getInstance(context, token, false, superAndMixpanelProperties);
         }

--- a/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelMessageCodec.java
+++ b/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelMessageCodec.java
@@ -1,0 +1,47 @@
+package com.mixpanel.mixpanel_flutter;
+
+import io.flutter.plugin.common.StandardMessageCodec;
+
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.Date;
+
+public class MixpanelMessageCodec extends StandardMessageCodec {
+    static final MixpanelMessageCodec instance = new MixpanelMessageCodec();
+    static final Charset UTF8 = Charset.forName("UTF8");
+    static final int DATE_TIME = 128;
+    static final int URI = 129;
+
+    @Override
+    protected void writeValue(ByteArrayOutputStream stream, Object value) {
+        if (value instanceof Date) {
+            stream.write(DATE_TIME);
+            writeLong(stream, ((Date) value).getTime());
+        } else if (value instanceof java.net.URI) {
+            stream.write(URI);
+            writeBytes(stream, ((java.net.URI) value).toString().getBytes(UTF8));
+        } else {
+            super.writeValue(stream, value);
+        }
+    }
+
+    @Override
+    protected Object readValueOfType(byte type, ByteBuffer buffer) {
+        switch (type) {
+            case (byte) DATE_TIME:
+                return new Date(buffer.getLong());
+            case (byte) URI:
+                final byte[] urlBytes = readBytes(buffer);
+                final String url = new String(urlBytes, UTF8);
+                try {
+                    return new URI(url);
+                } catch (URISyntaxException e) {
+                }
+            default:
+                return super.readValueOfType(type, buffer);
+        }
+    }
+}

--- a/example/lib/event.dart
+++ b/example/lib/event.dart
@@ -72,7 +72,9 @@ class _EventScreenState extends State<EventScreen> {
                         "deep2": [1, 2]
                       }
                     ]
-                  }
+                  },
+                  "date": DateTime.now(),
+                  "uri": Uri.parse("https://mixpanel.com")
                 });
               },
             ),

--- a/lib/codec/mixpanel_message_codec.dart
+++ b/lib/codec/mixpanel_message_codec.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// The codec utilized to encode data back and forth between
+/// the Dart application and the native platform.
+class MixpanelMessageCodec extends StandardMessageCodec {
+  /// Constructor.
+  const MixpanelMessageCodec();
+
+  static const int _kDateTime = 128;
+  static const int _kUri = 129;
+
+  @override
+  void writeValue(WriteBuffer buffer, dynamic value) {
+    if (value is DateTime) {
+      buffer.putUint8(_kDateTime);
+      buffer.putInt64(value.millisecondsSinceEpoch);
+    } else if (value is Uri) {
+      buffer.putUint8(_kUri);
+      final bytes = utf8.encoder.convert(value.toString());
+      writeSize(buffer, bytes.length);
+      buffer.putUint8List(bytes);
+    } else {
+      super.writeValue(buffer, value);
+    }
+  }
+
+  @override
+  dynamic readValueOfType(int type, ReadBuffer buffer) {
+    switch (type) {
+      case _kDateTime:
+        return DateTime.fromMillisecondsSinceEpoch(buffer.getInt64());
+      case _kUri:
+        final int length = readSize(buffer);
+        final String string = utf8.decoder.convert(buffer.getUint8List(length));
+        return Uri.parse(string);
+      default:
+        return super.readValueOfType(type, buffer);
+    }
+  }
+}

--- a/lib/mixpanel_flutter.dart
+++ b/lib/mixpanel_flutter.dart
@@ -3,10 +3,12 @@ import 'package:flutter/services.dart';
 import 'dart:developer' as developer;
 import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:mixpanel_flutter/codec/mixpanel_message_codec.dart';
 
 /// The primary class for integrating Mixpanel with your app.
 class Mixpanel {
-  static const MethodChannel _channel = const MethodChannel('mixpanel_flutter');
+  static const MethodChannel _channel = const MethodChannel(
+      'mixpanel_flutter', StandardMethodCodec(MixpanelMessageCodec()));
   static Map<String, String> _mixpanelProperties = {
     '\$lib_version': '1.4.5',
     'mp_lib': 'flutter',

--- a/test/mixpanel_flutter_test.dart
+++ b/test/mixpanel_flutter_test.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mixpanel_flutter/codec/mixpanel_message_codec.dart';
 import 'package:mixpanel_flutter/mixpanel_flutter.dart';
 
 void main() {
-  const MethodChannel channel = MethodChannel('mixpanel_flutter');
+  const MethodChannel channel = MethodChannel(
+      'mixpanel_flutter', StandardMethodCodec(MixpanelMessageCodec()));
   MethodCall? methodCall;
   late Mixpanel _mixpanel;
 
@@ -169,6 +171,37 @@ void main() {
           arguments: <String, dynamic>{
             'eventName': 'test event',
             'properties': <String, dynamic>{'a': 'b'},
+          },
+        ),
+      );
+    });
+
+    test('check track with DateTime property', () async {
+      final millis = DateTime.now().millisecondsSinceEpoch;
+      final date = DateTime.fromMillisecondsSinceEpoch(millis);
+      _mixpanel.track("test event", properties: {'date': date});
+      expect(
+        methodCall,
+        isMethodCall(
+          'track',
+          arguments: <String, dynamic>{
+            'eventName': 'test event',
+            'properties': <String, dynamic>{'date': date},
+          },
+        ),
+      );
+    });
+
+    test('check track with Uri property', () async {
+      final url = Uri.parse('https://mixpanel.com');
+      _mixpanel.track("test event", properties: {'url': url});
+      expect(
+        methodCall,
+        isMethodCall(
+          'track',
+          arguments: <String, dynamic>{
+            'eventName': 'test event',
+            'properties': <String, dynamic>{'url': url},
           },
         ),
       );


### PR DESCRIPTION
Using `DateTime` and `Uri` will throw ArgumentError.

> ArgumentError: Invalid argument: Instance of 'DateTime'

This pull request allows us to use dart `DateTime` and `Uri`.

```dart
_mixpanel.track("Track event with property", properties: {
                  "Cool Property": "Property Value",
                  "test": 233,
                  "complex": {
                    "child": [
                      {"deep1": "value1"},
                      {
                        "deep2": [1, 2]
                      }
                    ]
                  },
                  "date": DateTime.now(),
                  "uri": Uri.parse("https://mixpanel.com")
                })
```
