### PR TITLE
Added repo links

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,9 @@ name: mixpanel_flutter
 description: Official Flutter Tracking SDK for Mixpanel Analytics developed and maintained by Mixpanel, Inc.
 version: 1.6.0
 homepage: https://mixpanel.com
+repository: https://github.com/mixpanel/mixpanel-flutter
+issue_tracker: https://github.com/mixpanel/mixpanel-flutter/issues
+documentation: https://developer.mixpanel.com/docs/flutter
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
Repo links help users to navigate to mixpanels Github repository and documentation from pub.dev