### PR TITLE
add param 'trackAutomaticEvents' to 'init'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
     }
 }
 
@@ -23,7 +23,8 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
+    buildToolsVersion '30.0.3'
 
     defaultConfig {
         minSdkVersion 16

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,5 +34,5 @@ android {
 }
 
 dependencies {
-    implementation "com.mixpanel.android:mixpanel-android:6.3.0"
+    implementation "com.mixpanel.android:mixpanel-android:7.0.0"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,5 +35,5 @@ android {
 }
 
 dependencies {
-    implementation "com.mixpanel.android:mixpanel-android:7.0.0"
+    implementation "com.mixpanel.android:mixpanel-android:7.0.1"
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
+++ b/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
@@ -200,14 +200,17 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
             result.error("MixpanelFlutterException", e.getLocalizedMessage(), null);
             return;
         }
-        if (call.hasArgument("optOutTrackingDefault")) {
-            Boolean optOutTrackingDefault = call.<Boolean>argument("optOutTrackingDefault");
-            mixpanel = MixpanelAPI.getInstance(context, token,
-                    optOutTrackingDefault == null ? false : optOutTrackingDefault,
-                    superAndMixpanelProperties);
-        } else {
-            mixpanel = MixpanelAPI.getInstance(context, token, false, superAndMixpanelProperties);
-        }
+
+        Boolean optOutTrackingDefault = call.<Boolean>argument("optOutTrackingDefault");
+        Boolean trackAutomaticEvents = call.<Boolean>argument("trackAutomaticEvents");
+
+        mixpanel = MixpanelAPI.getInstance(context, token,
+                optOutTrackingDefault == null ? false : optOutTrackingDefault,
+                superAndMixpanelProperties, null, trackAutomaticEvents == null ? false : true);
+
+
+
+
         result.success(Integer.toString(mixpanel.hashCode()));
     }
 

--- a/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
+++ b/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
@@ -206,10 +206,7 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
 
         mixpanel = MixpanelAPI.getInstance(context, token,
                 optOutTrackingDefault == null ? false : optOutTrackingDefault,
-                superAndMixpanelProperties, null, trackAutomaticEvents == null ? false : true);
-
-
-
+                superAndMixpanelProperties, null, trackAutomaticEvents);
 
         result.success(Integer.toString(mixpanel.hashCode()));
     }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,8 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
-    ndkVersion "21.4.7075529"
+    compileSdkVersion 30
 
     lintOptions {
         disable 'InvalidPackage'
@@ -36,7 +35,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.mixpanel.mixpanel_flutter_example"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:4.1.1'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/example/lib/analytics.dart
+++ b/example/lib/analytics.dart
@@ -6,7 +6,7 @@ class MixpanelManager {
   static Future<Mixpanel> init() async {
     if (_instance == null) {
       _instance = await Mixpanel.init("YOUR_PROJECT_TOKEN",
-          optOutTrackingDefault: false);
+          optOutTrackingDefault: false, trackAutomaticEvents: true);
     }
     return _instance!;
   }

--- a/ios/Classes/SwiftMixpanelFlutterPlugin.swift
+++ b/ios/Classes/SwiftMixpanelFlutterPlugin.swift
@@ -153,7 +153,9 @@ public class SwiftMixpanelFlutterPlugin: NSObject, FlutterPlugin {
         mixpanelProperties = arguments["mixpanelProperties"] as? [String: String]
         let superProperties = arguments["superProperties"] as? [String: Any]
         self.token = token
+        let trackAutomaticEvents = arguments["trackAutomaticEvents"] as? Bool
         instance = Mixpanel.initialize(token: token!, instanceName: token!,
+                                       trackAutomaticEvents: trackAutomaticEvents ?? true,
                                        optOutTrackingByDefault: optOutTrackingDefault ?? false,
                                        superProperties: MixpanelTypeHandler.mixpanelProperties(properties: superProperties, mixpanelProperties: mixpanelProperties))
         instance?.flushInterval = defaultFlushInterval

--- a/ios/Classes/SwiftMixpanelFlutterPlugin.swift
+++ b/ios/Classes/SwiftMixpanelFlutterPlugin.swift
@@ -8,6 +8,7 @@ public class SwiftMixpanelFlutterPlugin: NSObject, FlutterPlugin {
     var token: String?
     var mixpanelProperties: [String: String]?
     let defaultFlushInterval = 60.0
+    var trackAutomaticEvents: Bool?
     
     public static func register(with registrar: FlutterPluginRegistrar) {
         let readWriter = MixpanelReaderWriter()
@@ -153,9 +154,10 @@ public class SwiftMixpanelFlutterPlugin: NSObject, FlutterPlugin {
         mixpanelProperties = arguments["mixpanelProperties"] as? [String: String]
         let superProperties = arguments["superProperties"] as? [String: Any]
         self.token = token
-        let trackAutomaticEvents = arguments["trackAutomaticEvents"] as Bool
-        instance = Mixpanel.initialize(token: token!, instanceName: token!,
-                                       trackAutomaticEvents: trackAutomaticEvents,
+        let trackAutomaticEvents = arguments["trackAutomaticEvents"] as! Bool
+        self.trackAutomaticEvents = trackAutomaticEvents
+        instance = Mixpanel.initialize(token: token!, trackAutomaticEvents: trackAutomaticEvents,
+                                        instanceName: token!,
                                        optOutTrackingByDefault: optOutTrackingDefault ?? false,
                                        superProperties: MixpanelTypeHandler.mixpanelProperties(properties: superProperties, mixpanelProperties: mixpanelProperties))
         instance?.flushInterval = defaultFlushInterval
@@ -170,7 +172,7 @@ public class SwiftMixpanelFlutterPlugin: NSObject, FlutterPlugin {
         
         var instance = Mixpanel.getInstance(name: token)
         if instance == nil {
-            instance = Mixpanel.initialize(token: token, instanceName: token)
+            instance = Mixpanel.initialize(token: token, trackAutomaticEvents: trackAutomaticEvents!, instanceName: token)
         }
         
         return instance

--- a/ios/Classes/SwiftMixpanelFlutterPlugin.swift
+++ b/ios/Classes/SwiftMixpanelFlutterPlugin.swift
@@ -153,9 +153,9 @@ public class SwiftMixpanelFlutterPlugin: NSObject, FlutterPlugin {
         mixpanelProperties = arguments["mixpanelProperties"] as? [String: String]
         let superProperties = arguments["superProperties"] as? [String: Any]
         self.token = token
-        let trackAutomaticEvents = arguments["trackAutomaticEvents"] as? Bool
+        let trackAutomaticEvents = arguments["trackAutomaticEvents"] as Bool
         instance = Mixpanel.initialize(token: token!, instanceName: token!,
-                                       trackAutomaticEvents: trackAutomaticEvents ?? true,
+                                       trackAutomaticEvents: trackAutomaticEvents,
                                        optOutTrackingByDefault: optOutTrackingDefault ?? false,
                                        superProperties: MixpanelTypeHandler.mixpanelProperties(properties: superProperties, mixpanelProperties: mixpanelProperties))
         instance?.flushInterval = defaultFlushInterval

--- a/ios/mixpanel_flutter.podspec
+++ b/ios/mixpanel_flutter.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Mixpanel-swift', '4.0.0'
+  s.dependency 'Mixpanel-swift', '4.0.1'
   s.platform = :ios, '9.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/mixpanel_flutter.podspec
+++ b/ios/mixpanel_flutter.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Mixpanel-swift', '3.3.0'
+  s.dependency 'Mixpanel-swift', '4.0.0'
   s.platform = :ios, '9.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/mixpanel_flutter.dart
+++ b/lib/mixpanel_flutter.dart
@@ -27,14 +27,18 @@ class Mixpanel {
   ///  * [token] your project token.
   ///  * [optOutTrackingDefault] Optional Whether or not Mixpanel can start tracking by default. See
   ///  optOutTracking()
+  ///  * [trackAutomaticEvents] Optional Whether or not to collect common mobile events
+  ///  include app sessions, first app opens, app updated, etc.
   ///  * [superProperties] Optional super properties to register
   ///  * [config] Optional A dictionary of config options to override (WEB ONLY)
   ///
   static Future<Mixpanel> init(String token,
       {bool optOutTrackingDefault = false,
+        bool trackAutomaticEvents = true,
         Map<String, dynamic>? superProperties, Map<String, dynamic>? config}) async {
     var allProperties = <String, dynamic>{'token': token};
     allProperties['optOutTrackingDefault'] = optOutTrackingDefault;
+    allProperties['trackAutomaticEvents'] = trackAutomaticEvents;
     allProperties['mixpanelProperties'] = _mixpanelProperties;
     allProperties['superProperties'] = superProperties;
     allProperties['config'] = config;

--- a/lib/mixpanel_flutter.dart
+++ b/lib/mixpanel_flutter.dart
@@ -27,14 +27,14 @@ class Mixpanel {
   ///  * [token] your project token.
   ///  * [optOutTrackingDefault] Optional Whether or not Mixpanel can start tracking by default. See
   ///  optOutTracking()
-  ///  * [trackAutomaticEvents] Optional Whether or not to collect common mobile events
+  ///  * [trackAutomaticEvents] Required Whether or not to collect common mobile events
   ///  include app sessions, first app opens, app updated, etc.
   ///  * [superProperties] Optional super properties to register
   ///  * [config] Optional A dictionary of config options to override (WEB ONLY)
   ///
   static Future<Mixpanel> init(String token,
       {bool optOutTrackingDefault = false,
-        bool trackAutomaticEvents = true,
+        required bool trackAutomaticEvents,
         Map<String, dynamic>? superProperties, Map<String, dynamic>? config}) async {
     var allProperties = <String, dynamic>{'token': token};
     allProperties['optOutTrackingDefault'] = optOutTrackingDefault;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,21 +7,21 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "19.0.0"
+    version: "31.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "2.8.0"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.3.1"
   async:
     dependency: transitive
     description:
@@ -56,7 +56,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.5"
   clock:
     dependency: transitive
     description:
@@ -77,21 +77,21 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.2"
   fake_async:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0"
+    version: "6.1.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -127,35 +127,35 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   io:
     dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   js:
     dependency: "direct main"
     description:
@@ -169,7 +169,7 @@ packages:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   matcher:
     dependency: transitive
     description:
@@ -190,7 +190,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.2"
   node_preamble:
     dependency: transitive
     description:
@@ -204,7 +204,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   path:
     dependency: transitive
     description:
@@ -218,49 +218,49 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.1"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -356,35 +356,35 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0+1"
+    version: "7.5.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.2.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/test/mixpanel_flutter_test.dart
+++ b/test/mixpanel_flutter_test.dart
@@ -18,7 +18,7 @@ void main() {
       });
 
       _mixpanel =
-          await Mixpanel.init("test token", optOutTrackingDefault: false);
+          await Mixpanel.init("test token", optOutTrackingDefault: false, trackAutomaticEvents: true);
     });
 
     tearDown(() {
@@ -28,7 +28,7 @@ void main() {
 
     test('check initialize call', () async {
       _mixpanel =
-          await Mixpanel.init("test token", optOutTrackingDefault: false);
+          await Mixpanel.init("test token", optOutTrackingDefault: false, trackAutomaticEvents: true);
       expect(
         methodCall,
         isMethodCall(
@@ -36,6 +36,7 @@ void main() {
           arguments: <String, dynamic>{
             'token': "test token",
             'optOutTrackingDefault': false,
+            'trackAutomaticEvents': true,
             'mixpanelProperties': {
               '\$lib_version': '1.6.0',
               'mp_lib': 'flutter',
@@ -49,7 +50,7 @@ void main() {
 
     test('check initialize call with optOutTracking true', () async {
       _mixpanel =
-          await Mixpanel.init("test token", optOutTrackingDefault: true);
+          await Mixpanel.init("test token", optOutTrackingDefault: true, trackAutomaticEvents: true);
       expect(
         methodCall,
         isMethodCall(
@@ -57,6 +58,7 @@ void main() {
           arguments: <String, dynamic>{
             'token': "test token",
             'optOutTrackingDefault': true,
+            'trackAutomaticEvents': true,
             'mixpanelProperties': {
               '\$lib_version': '1.6.0',
               'mp_lib': 'flutter',
@@ -67,6 +69,29 @@ void main() {
         ),
       );
     });
+
+    test('check initialize call with trackAutomaticEvents false', () async {
+      _mixpanel =
+      await Mixpanel.init("test token", optOutTrackingDefault: true, trackAutomaticEvents: false);
+      expect(
+        methodCall,
+        isMethodCall(
+          'initialize',
+          arguments: <String, dynamic>{
+            'token': "test token",
+            'optOutTrackingDefault': true,
+            'trackAutomaticEvents': false,
+            'mixpanelProperties': {
+              '\$lib_version': '1.6.0',
+              'mp_lib': 'flutter',
+            },
+            'superProperties': null,
+            'config': null,
+          },
+        ),
+      );
+    });
+
 
     test('check setServerURL', () async {
       _mixpanel.setServerURL("https://api-eu.mixpanel.com");


### PR DESCRIPTION
Since this PR, we are deprecating the `Automatically collect common mobile events`
 setting from Mixpanel website in favor of reducing crashes and race conditions when collecting common mobile events.

<img width="1717" alt="image" src="https://user-images.githubusercontent.com/36679208/178829498-0c74a59d-9266-477a-9ec5-d2fe290aed51.png">

Alternatively, you can specify `trackAutomaticEvents` in `init` 