### PR TITLE
bump iOS version to 4.1.4

### DIFF
--- a/ios/mixpanel_flutter.podspec
+++ b/ios/mixpanel_flutter.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Mixpanel-swift', '4.1.0'
+  s.dependency 'Mixpanel-swift', '4.1.4'
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
resolve https://github.com/mixpanel/mixpanel-flutter/issues/117


## [v4.1.3](https://github.com/mixpanel/mixpanel-swift/tree/v4.1.3) (2023-06-16)
### Fixes
- Fix potential crash automatic properties https://github.com/mixpanel/mixpanel-swift/pull/608

## [v4.1.4](https://github.com/mixpanel/mixpanel-swift/tree/v4.1.4) (2023-07-19)
### Fixes
- Re-work thread safety mechanisms for flush process https://github.com/mixpanel/mixpanel-swift/pull/611
