### PR TITLE
Lower js constraint to allow 0.6.x

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  js: ^0.7.1
+  js: ">=0.6.0 <0.8.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
```
Because google_maps_flutter >=2.6.0 depends on google_maps_flutter_web ^0.5.6 which depends on google_maps ^7.1.0, google_maps_flutter
  >=2.6.0 requires google_maps ^7.1.0.
And because google_maps >=6.3.0 depends on js ^0.6.3 and mixpanel_flutter >=2.3.0 depends on js ^0.7.1, google_maps_flutter >=2.6.0 is
  incompatible with mixpanel_flutter >=2.3.0.
So, because <app_name> depends on both google_maps_flutter ^2.6.0 and mixpanel_flutter ^2.3.0, version solving failed.
```

I'm on the latest version of both `google_maps_flutter` and `mixpanel_flutter`. Upgrading the `js` dep to only `^0.7.x` broke compatibility with `google_maps_flutter`, and I'm sure other plugins were affected as well.

This PR lowers the constraint to allow 0.6.x.