### PR TITLE
V1 embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 #
 
+## v2.4.0
+- Remove Flutter V1 embedding reference
+
+#
+
 ## [v2.3.3](https://github.com/mixpanel/mixpanel-flutter/tree/v2.3.3) (2024-09-25)
 
 ### Fixes

--- a/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
+++ b/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
@@ -19,7 +19,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 import com.mixpanel.android.mpmetrics.MixpanelAPI;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mixpanel_flutter
 description: Official Flutter Tracking SDK for Mixpanel Analytics developed and maintained by Mixpanel, Inc.
-version: 2.3.3
+version: 2.4.0
 homepage: https://mixpanel.com
 repository: https://github.com/mixpanel/mixpanel-flutter
 issue_tracker: https://github.com/mixpanel/mixpanel-flutter/issues


### PR DESCRIPTION
Flutter 3.27 doesn't support V1 embedding.
This import is unused and hence the functionality of plugin should remain intact.