### PR TITLE
Migrate to Flutter Embedding v2: Remove PluginRegistry.Registrar Usage

### DIFF
--- a/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
+++ b/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
@@ -19,7 +19,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 import com.mixpanel.android.mpmetrics.MixpanelAPI;
 


### PR DESCRIPTION
This PR migrates the plugin to Flutter Embedding v2 by removing the deprecated PluginRegistry.Registrar usage. With this change, the plugin now registers itself using the new onAttachedToEngine and onAttachedToActivity callbacks, ensuring compatibility with the latest Flutter versions. This update resolves the build errors encountered when using the old registration method and streamlines the integration process for Flutter apps.

- Removed:
   The registerWith(Registrar registrar) method and its associated import for PluginRegistry.Registrar.

- Updated:
   Plugin registration now solely relies on the onAttachedToEngine and onAttachedToActivity methods as recommended by Flutter Embedding v2.
   

Please review the changes and let me know if further adjustments are needed.