### PR TITLE
Move Mixpanel Android Method Channel Initialization back to onAttachedToEngine

### DIFF
--- a/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
+++ b/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
@@ -47,6 +47,8 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
         // Store references for lazy initialization to avoid ANR during plugin registration
         this.flutterPluginBinding = flutterPluginBinding;
         this.context = flutterPluginBinding.getApplicationContext();
+
+        initializeMethodChannel();
     }
 
     @Override
@@ -189,9 +191,6 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
     }
 
     private void handleInitialize(MethodCall call, Result result) {
-        // Lazy initialization of MethodChannel to avoid ANR
-        initializeMethodChannel();
-        
         final String token = call.argument("token");
         if (token == null) {
             throw new RuntimeException("Your Mixpanel Token was not set");


### PR DESCRIPTION
Proposed Fix for - https://github.com/mixpanel/mixpanel-flutter/issues/195