### PR TITLE
Update CHANGELOG for v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 #
 
-## Unreleased
+## [v2.6.0](https://github.com/mixpanel/mixpanel-flutter/tree/v2.6.0) (2026-04-09)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Enhancements
 
-- Update Mixpanel Android SDK to 8.5.0
-- Update Mixpanel Swift SDK to 6.2.0
-- `updateContext()` now calls `setContext` on iOS and Android instead of being a no-op
-- `loadFlags()` now supported on web via `mixpanel.flags.load_flags()`
+- Add OSX desktop support [\#220](https://github.com/mixpanel/mixpanel-flutter/pull/220)
+- `loadFlags()` and `setContext()` support on all platforms [\#210](https://github.com/mixpanel/mixpanel-flutter/pull/210)
+- Refactor Mixpanel instance management in iOS Flutter plugin [\#221](https://github.com/mixpanel/mixpanel-flutter/pull/221)
+
 
 #
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 ### Enhancements
 
 - Add OSX desktop support [\#220](https://github.com/mixpanel/mixpanel-flutter/pull/220)
-- `loadFlags()` and `setContext()` support on all platforms [\#210](https://github.com/mixpanel/mixpanel-flutter/pull/210)
+- Update Mixpanel Android SDK to 8.5.0
+- Update Mixpanel Swift SDK to 6.2.0
+- `updateContext()` now calls `setContext` on iOS and Android instead of being a no-op [\#210](https://github.com/mixpanel/mixpanel-flutter/pull/210)
+- `loadFlags()` now supported on web via `mixpanel.flags.load_flags()` [\#210](https://github.com/mixpanel/mixpanel-flutter/pull/210)
 - Refactor Mixpanel instance management in iOS Flutter plugin [\#221](https://github.com/mixpanel/mixpanel-flutter/pull/221)
 
 


### PR DESCRIPTION
## Summary
- Replace `Unreleased` heading with v2.6.0 release date (2026-04-09)