### PR TITLE
feat(analytics): Feature Flag Persistence

### DIFF
--- a/.claude/context/architecture/ARCHITECTURE.md
+++ b/.claude/context/architecture/ARCHITECTURE.md
@@ -224,9 +224,9 @@ Mixpanel Servers
 
 ## Platform Dependencies
 
-- **Android**: Mixpanel Android SDK v8.0.3
-- **iOS**: Mixpanel-swift 6.1.0
-- **macOS**: Mixpanel-swift 6.1.0
+- **Android**: Mixpanel Android SDK v8.7.0
+- **iOS**: Mixpanel-swift 6.4.0
+- **macOS**: Mixpanel-swift 6.4.0
 - **Web**: Mixpanel JavaScript library (loaded from CDN)
 
 ## Example Usage

--- a/.claude/context/architecture/system-design.md
+++ b/.claude/context/architecture/system-design.md
@@ -27,7 +27,7 @@ The Mixpanel Flutter SDK implements a federated plugin architecture that provide
 │  - Type conversion  │ - Type handler│  - safeJsify()      │
 ├─────────────────────┼───────────────┼──────────────────────┤
 │ Mixpanel Android    │ Mixpanel-swift│  Mixpanel JS        │
-│    SDK v8.5.1       │   SDK v6.1.0  │   (CDN loaded)      │
+│    SDK v8.7.0       │   SDK v6.4.0  │   (CDN loaded)      │
 └─────────────────────┴───────────────┴──────────────────────┘
                               ↓
                     Mixpanel Analytics Servers

--- a/.claude/context/codebase-map.md
+++ b/.claude/context/codebase-map.md
@@ -75,7 +75,7 @@ mixpanel-flutter/
 
 - **ios/mixpanel_flutter.podspec**: iOS pod configuration
   - iOS deployment target: 12.0
-  - Mixpanel-swift dependency: 6.1.0
+  - Mixpanel-swift dependency: 6.4.0
   - Swift version: 5.0
 
 - **analysis_options.yaml**: Dart static analysis rules

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,7 +72,7 @@ android/
     └── MixpanelFlutterHelper.java  # Validation helpers
 
 ios/
-├── mixpanel_flutter.podspec        # iOS package (Mixpanel-swift 6.1.0)
+├── mixpanel_flutter.podspec        # iOS package (Mixpanel-swift 6.4.0)
 └── Classes/
     ├── SwiftMixpanelFlutterPlugin.swift # iOS platform channel
     └── MixpanelTypeHandler.swift        # Type serialization
@@ -213,8 +213,8 @@ When adding a new SDK method:
 ## Dependencies
 
 **Production**:
-- Mixpanel Android SDK 8.5.1 (in `android/build.gradle`)
-- Mixpanel-swift 6.1.0 (in `ios/mixpanel_flutter.podspec` and `macos/mixpanel_flutter.podspec`)
+- Mixpanel Android SDK 8.7.0 (in `android/build.gradle`)
+- Mixpanel-swift 6.4.0 (in `ios/mixpanel_flutter.podspec` and `macos/mixpanel_flutter.podspec`)
 - Mixpanel JS (loaded from CDN in web/index.html)
 
 **Dev**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This is the official Mixpanel Flutter SDK - a Flutter plugin providing analytics
 ### Key Technologies
 - **Flutter/Dart**: Core SDK implementation
 - **Platform Channels**: Communication between Dart and native code
-- **Native SDKs**: Mixpanel-Android (v8.5.1), Mixpanel-Swift (6.1.0), Mixpanel-JS (CDN)
+- **Native SDKs**: Mixpanel-Android (v8.7.0), Mixpanel-Swift (6.4.0), Mixpanel-JS (CDN)
 - **Custom Serialization**: MixpanelMessageCodec for complex types
 - **Testing**: Flutter unit tests with mocked platform channels
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,9 @@ Future<void> methodName(parameters) async {
 - `MixpanelGroup` - Group analytics management (accessible via `mixpanel.getGroup()`)
 
 ### Platform Dependencies
-- Android: Mixpanel Android SDK v8.5.1
-- iOS: Mixpanel-swift 6.1.0
-- macOS: Mixpanel-swift 6.1.0
+- Android: Mixpanel Android SDK v8.7.0
+- iOS: Mixpanel-swift 6.4.0
+- macOS: Mixpanel-swift 6.4.0
 - Web: Mixpanel JavaScript library (loaded from CDN)
 
 ## Development Commands

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,5 +47,5 @@ android {
 
 dependencies {
     // Use the Mixpanel Android SDK
-    implementation "com.mixpanel.android:mixpanel-android:8.5.1"
+    implementation "com.mixpanel.android:mixpanel-android:8.7.0"
 }

--- a/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
+++ b/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
@@ -763,23 +763,23 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
             case "networkOnly":
                 return VariantLookupPolicy.networkOnly();
             case "persistenceUntilNetworkSuccess":
-                return VariantLookupPolicy.persistenceUntilNetworkSuccess(readTtlMillis(policyMap));
+                return VariantLookupPolicy.persistenceUntilNetworkSuccess(readPersistenceTtlMillis(policyMap));
             case "networkFirst":
-                return VariantLookupPolicy.networkFirst(readTtlMillis(policyMap));
+                return VariantLookupPolicy.networkFirst(readPersistenceTtlMillis(policyMap));
             default:
                 android.util.Log.w("Mixpanel", "Unknown variantLookupPolicy '" + kind + "', falling back to networkOnly");
                 return VariantLookupPolicy.networkOnly();
         }
     }
 
-    private long readTtlMillis(Map<String, Object> policyMap) {
-        Object raw = policyMap.get("ttlMs");
+    private long readPersistenceTtlMillis(Map<String, Object> policyMap) {
+        Object raw = policyMap.get("persistenceTtlMillis");
         if (raw instanceof Number) {
             return ((Number) raw).longValue();
         }
         // Match the Dart-side default (24 hours). Should never hit this path in
-        // practice — the Dart layer always serializes ttlMs for non-networkOnly
-        // policies — but keep the constant in sync to stay safe.
+        // practice — the Dart layer always serializes persistenceTtlMillis for
+        // non-networkOnly policies — but keep the constant in sync to stay safe.
         return java.util.concurrent.TimeUnit.HOURS.toMillis(24);
     }
 

--- a/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
+++ b/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
@@ -20,8 +20,11 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 
+import com.mixpanel.android.mpmetrics.FeatureFlagOptions;
 import com.mixpanel.android.mpmetrics.MixpanelAPI;
+import com.mixpanel.android.mpmetrics.MixpanelFlagVariant;
 import com.mixpanel.android.mpmetrics.MixpanelOptions;
+import com.mixpanel.android.mpmetrics.VariantLookupPolicy;
 
 /**
  * MixpanelFlutterPlugin
@@ -241,6 +244,7 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
         Map<String, Object> featureFlagsMap = call.<HashMap<String, Object>>argument("featureFlags");
         Boolean featureFlagsEnabled = null;
         JSONObject featureFlagsContext = null;
+        VariantLookupPolicy variantLookupPolicy = null;
         if (featureFlagsMap != null) {
             Object enabledValue = featureFlagsMap.get("enabled");
             if (enabledValue instanceof Boolean) {
@@ -256,6 +260,12 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
                     android.util.Log.w("Mixpanel", "Failed to parse feature flags context: " + e.getMessage());
                 }
             }
+            Object policyValue = featureFlagsMap.get("variantLookupPolicy");
+            if (policyValue instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> policyMap = (Map<String, Object>) policyValue;
+                variantLookupPolicy = parseVariantLookupPolicy(policyMap);
+            }
         }
 
         // Build MixpanelOptions with feature flags configuration
@@ -264,10 +274,14 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
                 .superProperties(superAndMixpanelProperties);
 
         if (featureFlagsEnabled != null && featureFlagsEnabled) {
-            optionsBuilder.featureFlagsEnabled(true);
+            FeatureFlagOptions.Builder ffBuilder = new FeatureFlagOptions.Builder().enabled(true);
             if (featureFlagsContext != null) {
-                optionsBuilder.featureFlagsContext(featureFlagsContext);
+                ffBuilder.context(featureFlagsContext);
             }
+            if (variantLookupPolicy != null) {
+                ffBuilder.variantLookupPolicy(variantLookupPolicy);
+            }
+            optionsBuilder.featureFlagOptions(ffBuilder.build());
         }
 
         boolean trackAutoEvents = trackAutomaticEvents == null ? true : trackAutomaticEvents;
@@ -701,23 +715,72 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
         });
     }
 
-    private com.mixpanel.android.mpmetrics.MixpanelFlagVariant mapToFlagVariant(Map<String, Object> map) {
+    private MixpanelFlagVariant mapToFlagVariant(Map<String, Object> map) {
         if (map == null) {
-            return new com.mixpanel.android.mpmetrics.MixpanelFlagVariant("", null);
+            return new MixpanelFlagVariant("", null);
         }
         String key = (String) map.get("key");
         Object value = map.get("value");
-        return new com.mixpanel.android.mpmetrics.MixpanelFlagVariant(key != null ? key : "", value);
+        return new MixpanelFlagVariant(key != null ? key : "", value);
     }
 
-    private Map<String, Object> flagVariantToMap(com.mixpanel.android.mpmetrics.MixpanelFlagVariant variant) {
+    private Map<String, Object> flagVariantToMap(MixpanelFlagVariant variant) {
         Map<String, Object> map = new HashMap<>();
         map.put("key", variant.key);
         map.put("value", variant.value);
         map.put("experimentId", variant.experimentID);
         map.put("isExperimentActive", variant.isExperimentActive);
         map.put("isQaTester", variant.isQATester);
+        map.put("source", flagVariantSourceToMap(variant.source));
         return map;
+    }
+
+    private Map<String, Object> flagVariantSourceToMap(MixpanelFlagVariant.Source source) {
+        // Native source is non-null on every variant the SDK returns. Defensive
+        // null-check kept in case the bridge runs against an older native build
+        // that still allowed null sources.
+        if (source == null) {
+            return null;
+        }
+        Map<String, Object> map = new HashMap<>();
+        if (source instanceof MixpanelFlagVariant.Source.Persistence) {
+            map.put("kind", "persistence");
+            map.put("persistedAtMillis", ((MixpanelFlagVariant.Source.Persistence) source).persistedAtMillis);
+        } else if (source instanceof MixpanelFlagVariant.Source.Network) {
+            map.put("kind", "network");
+        } else {
+            map.put("kind", "fallback");
+        }
+        return map;
+    }
+
+    private VariantLookupPolicy parseVariantLookupPolicy(Map<String, Object> policyMap) {
+        Object kind = policyMap.get("policy");
+        if (!(kind instanceof String)) {
+            return null;
+        }
+        switch ((String) kind) {
+            case "networkOnly":
+                return VariantLookupPolicy.networkOnly();
+            case "persistenceUntilNetworkSuccess":
+                return VariantLookupPolicy.persistenceUntilNetworkSuccess(readTtlMillis(policyMap));
+            case "networkFirst":
+                return VariantLookupPolicy.networkFirst(readTtlMillis(policyMap));
+            default:
+                android.util.Log.w("Mixpanel", "Unknown variantLookupPolicy '" + kind + "', falling back to networkOnly");
+                return VariantLookupPolicy.networkOnly();
+        }
+    }
+
+    private long readTtlMillis(Map<String, Object> policyMap) {
+        Object raw = policyMap.get("ttlMs");
+        if (raw instanceof Number) {
+            return ((Number) raw).longValue();
+        }
+        // Match the Dart-side default (24 hours). Should never hit this path in
+        // practice — the Dart layer always serializes ttlMs for non-networkOnly
+        // policies — but keep the constant in sync to stay safe.
+        return java.util.concurrent.TimeUnit.HOURS.toMillis(24);
     }
 
     @Override

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -3,17 +3,17 @@ PODS:
   - json-enum (1.2.3)
   - jsonlogic (1.2.4):
     - json-enum (~> 1.2.3)
-  - Mixpanel-swift (6.3.0):
+  - Mixpanel-swift (6.4.0):
     - jsonlogic (~> 1.2.0)
-    - Mixpanel-swift/Complete (= 6.3.0)
+    - Mixpanel-swift/Complete (= 6.4.0)
     - MixpanelSwiftCommon (~> 1.0.0)
-  - Mixpanel-swift/Complete (6.3.0):
+  - Mixpanel-swift/Complete (6.4.0):
     - jsonlogic (~> 1.2.0)
     - MixpanelSwiftCommon (~> 1.0.0)
-  - mixpanel_flutter (2.6.2):
+  - mixpanel_flutter (2.7.0):
     - Flutter
-    - Mixpanel-swift (= 6.3.0)
-  - MixpanelSwiftCommon (1.0.0)
+    - Mixpanel-swift (= 6.4.0)
+  - MixpanelSwiftCommon (1.0.1)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -36,9 +36,9 @@ SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   json-enum: 57ad746d2f0d7852796e9aa50267bd84a778222e
   jsonlogic: 006f892470384401b8ca5b5d8d4cdadb3a0d5c9b
-  Mixpanel-swift: f8bbfb3ebd1c6debd8aab574e3e54433bd51c724
-  mixpanel_flutter: ba62a45188f606feea09042442da8ad996e19213
-  MixpanelSwiftCommon: 562decd3d15661111df484830fb958f389f2f4aa
+  Mixpanel-swift: 9eb2ea2d0463970687c984e07040669f787b7a49
+  mixpanel_flutter: ab9b5c729fe429cd185832ceac24b11a91ef0da9
+  MixpanelSwiftCommon: 6fc461403945422a2e1d0989d712c0db2c26ecdb
 
 PODFILE CHECKSUM: a57f30d18f102dd3ce366b1d62a55ecbef2158e5
 

--- a/example/lib/feature_flags.dart
+++ b/example/lib/feature_flags.dart
@@ -129,6 +129,14 @@ class _FeatureFlagsScreenState extends State<FeatureFlagsScreen> {
                     variant.isExperimentActive == expectedIsExperimentActive
                         ? '✓'
                         : '✗';
+                final src = variant.source;
+                final sourceLabel = src is PersistenceSource
+                    ? 'persistence (persistedAt: ${src.persistedAt})'
+                    : src is NetworkSource
+                        ? 'network'
+                        : src is FallbackSource
+                            ? 'fallback'
+                            : 'unknown';
                 final alertText = '''Expected:
   key: $expectedKey
   experimentId: $expectedExperimentId
@@ -139,7 +147,8 @@ Actual:
   value: ${variant.value}
   experimentId: ${variant.experimentId}  $expIdMatch
   isExperimentActive: ${variant.isExperimentActive}  $activeMatch
-  isQaTester: ${variant.isQaTester}''';
+  isQaTester: ${variant.isQaTester}
+  source: $sourceLabel''';
                 _showAlert(context, "Full Variant: $flagName", alertText);
               },
             ),

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -3,17 +3,17 @@ PODS:
   - json-enum (1.2.3)
   - jsonlogic (1.2.4):
     - json-enum (~> 1.2.3)
-  - Mixpanel-swift (6.3.0):
+  - Mixpanel-swift (6.4.0):
     - jsonlogic (~> 1.2.0)
-    - Mixpanel-swift/Complete (= 6.3.0)
+    - Mixpanel-swift/Complete (= 6.4.0)
     - MixpanelSwiftCommon (~> 1.0.0)
-  - Mixpanel-swift/Complete (6.3.0):
+  - Mixpanel-swift/Complete (6.4.0):
     - jsonlogic (~> 1.2.0)
     - MixpanelSwiftCommon (~> 1.0.0)
   - mixpanel_flutter (2.6.2):
     - FlutterMacOS
-    - Mixpanel-swift (= 6.3.0)
-  - MixpanelSwiftCommon (1.0.0)
+    - Mixpanel-swift (= 6.4.0)
+  - MixpanelSwiftCommon (1.0.1)
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
@@ -36,9 +36,9 @@ SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   json-enum: 57ad746d2f0d7852796e9aa50267bd84a778222e
   jsonlogic: 006f892470384401b8ca5b5d8d4cdadb3a0d5c9b
-  Mixpanel-swift: f8bbfb3ebd1c6debd8aab574e3e54433bd51c724
-  mixpanel_flutter: 0c8f7a60b42ebf11617dcec53d1ee1281120e2f5
-  MixpanelSwiftCommon: 562decd3d15661111df484830fb958f389f2f4aa
+  Mixpanel-swift: 9eb2ea2d0463970687c984e07040669f787b7a49
+  mixpanel_flutter: 6921df15bfe7eaba0e817ab40b4ce6221c06a956
+  MixpanelSwiftCommon: 6fc461403945422a2e1d0989d712c0db2c26ecdb
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -142,7 +142,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.6.2"
+    version: "2.7.0"
   path:
     dependency: transitive
     description:

--- a/ios/mixpanel_flutter.podspec
+++ b/ios/mixpanel_flutter.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Mixpanel-swift', '6.3.0'
+  s.dependency 'Mixpanel-swift', '6.4.0'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/mixpanel_flutter.dart
+++ b/lib/mixpanel_flutter.dart
@@ -223,11 +223,11 @@ class MixpanelFlagVariant {
 ///   session that used a persisting policy is wiped on init.
 /// - [VariantLookupPolicy.persistenceUntilNetworkSuccess]: serve persisted
 ///   variants immediately on init (within
-///   [PersistenceUntilNetworkSuccessPolicy.ttl]), refresh from the network in
-///   the background.
+///   [PersistenceUntilNetworkSuccessPolicy.persistenceTtl]), refresh from the
+///   network in the background.
 /// - [VariantLookupPolicy.networkFirst]: await the network call; only fall
-///   back to persisted variants (within [NetworkFirstPolicy.ttl]) if the
-///   network call fails.
+///   back to persisted variants (within [NetworkFirstPolicy.persistenceTtl])
+///   if the network call fails.
 ///
 /// Inspect [MixpanelFlagVariant.source] on a served variant to tell whether
 /// it came from persistence or a fresh network response.
@@ -238,14 +238,22 @@ abstract class VariantLookupPolicy {
   /// Wipes any stale on-disk data from a prior session on init.
   const factory VariantLookupPolicy.networkOnly() = NetworkOnlyPolicy;
 
-  /// Serve persisted variants immediately on init (within [ttl]), then
-  /// refresh from the network in the background.
+  /// Serve persisted variants immediately on init (within [persistenceTtl]),
+  /// then refresh from the network in the background.
+  ///
+  /// **Web:** not yet supported by the Mixpanel JS SDK at the time of this
+  /// release. On web this policy is silently treated as [networkOnly] until
+  /// JS SDK support ships. Check the Mixpanel JS docs for availability.
   const factory VariantLookupPolicy.persistenceUntilNetworkSuccess(
-      {Duration ttl}) = PersistenceUntilNetworkSuccessPolicy;
+      {Duration persistenceTtl}) = PersistenceUntilNetworkSuccessPolicy;
 
-  /// Await the network call; fall back to persisted variants (within [ttl])
-  /// only on network failure.
-  const factory VariantLookupPolicy.networkFirst({Duration ttl}) =
+  /// Await the network call; fall back to persisted variants (within
+  /// [persistenceTtl]) only on network failure.
+  ///
+  /// **Web:** not yet supported by the Mixpanel JS SDK at the time of this
+  /// release. On web this policy is silently treated as [networkOnly] until
+  /// JS SDK support ships. Check the Mixpanel JS docs for availability.
+  const factory VariantLookupPolicy.networkFirst({Duration persistenceTtl}) =
       NetworkFirstPolicy;
 
   /// Serializes this policy for the platform channel.
@@ -264,15 +272,15 @@ class NetworkOnlyPolicy extends VariantLookupPolicy {
 class PersistenceUntilNetworkSuccessPolicy extends VariantLookupPolicy {
   /// Maximum age of a persisted variant set before it is ignored on read.
   /// Defaults to 24 hours.
-  final Duration ttl;
+  final Duration persistenceTtl;
 
   const PersistenceUntilNetworkSuccessPolicy(
-      {this.ttl = const Duration(hours: 24)});
+      {this.persistenceTtl = const Duration(hours: 24)});
 
   @override
   Map<String, dynamic> toMap() => {
         'policy': 'persistenceUntilNetworkSuccess',
-        'ttlMs': ttl.inMilliseconds,
+        'persistenceTtlMillis': persistenceTtl.inMilliseconds,
       };
 }
 
@@ -280,13 +288,15 @@ class PersistenceUntilNetworkSuccessPolicy extends VariantLookupPolicy {
 class NetworkFirstPolicy extends VariantLookupPolicy {
   /// Maximum age of a persisted variant set before it is ignored on read.
   /// Defaults to 24 hours.
-  final Duration ttl;
+  final Duration persistenceTtl;
 
-  const NetworkFirstPolicy({this.ttl = const Duration(hours: 24)});
+  const NetworkFirstPolicy({this.persistenceTtl = const Duration(hours: 24)});
 
   @override
-  Map<String, dynamic> toMap() =>
-      {'policy': 'networkFirst', 'ttlMs': ttl.inMilliseconds};
+  Map<String, dynamic> toMap() => {
+        'policy': 'networkFirst',
+        'persistenceTtlMillis': persistenceTtl.inMilliseconds,
+      };
 }
 
 /// Configuration options for feature flags.

--- a/lib/mixpanel_flutter.dart
+++ b/lib/mixpanel_flutter.dart
@@ -264,6 +264,11 @@ class NetworkOnlyPolicy extends VariantLookupPolicy {
 class PersistenceUntilNetworkSuccessPolicy extends VariantLookupPolicy {
   /// Maximum age of a persisted variant set before it is ignored on read.
   /// Defaults to 24 hours.
+  ///
+  /// Edge cases (handled by the native SDKs):
+  /// - [Duration.zero] — entries are always considered expired on every check.
+  /// - Negative durations — invalid; coerced to 24 hours and a warning is
+  ///   logged on the native side.
   final Duration ttl;
 
   const PersistenceUntilNetworkSuccessPolicy(
@@ -280,6 +285,11 @@ class PersistenceUntilNetworkSuccessPolicy extends VariantLookupPolicy {
 class NetworkFirstPolicy extends VariantLookupPolicy {
   /// Maximum age of a persisted variant set before it is ignored on read.
   /// Defaults to 24 hours.
+  ///
+  /// Edge cases (handled by the native SDKs):
+  /// - [Duration.zero] — entries are always considered expired on every check.
+  /// - Negative durations — invalid; coerced to 24 hours and a warning is
+  ///   logged on the native side.
   final Duration ttl;
 
   const NetworkFirstPolicy({this.ttl = const Duration(hours: 24)});

--- a/lib/mixpanel_flutter.dart
+++ b/lib/mixpanel_flutter.dart
@@ -6,6 +6,97 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/services.dart';
 import 'package:mixpanel_flutter/codec/mixpanel_message_codec.dart';
 
+/// Identifies where a served [MixpanelFlagVariant] came from. Non-null on
+/// every variant the SDK returns:
+/// - [NetworkSource]: the variant was assigned by the most recent successful
+///   `/flags/` network response.
+/// - [PersistenceSource]: the variant was loaded from the on-disk persistence
+///   layer; [PersistenceSource.persistedAt] is when the variant set was
+///   originally written.
+/// - [FallbackSource]: the SDK could not produce a real variant and returned
+///   the developer-supplied fallback unchanged. Variants the developer
+///   constructs directly also default to this source, since the only reason
+///   to build one is to pass it as a fallback.
+///
+/// The persistence timestamp lives only on [PersistenceSource] so invalid
+/// combinations like "network with a timestamp" are unrepresentable.
+abstract class MixpanelFlagVariantSource {
+  const MixpanelFlagVariantSource();
+
+  const factory MixpanelFlagVariantSource.network() = NetworkSource;
+  factory MixpanelFlagVariantSource.persistence(
+      {required DateTime persistedAt}) = PersistenceSource;
+  const factory MixpanelFlagVariantSource.fallback() = FallbackSource;
+
+  /// Decodes a source map produced by the platform handlers. Falls back to
+  /// [FallbackSource] for missing, malformed, or unrecognized payloads.
+  static MixpanelFlagVariantSource fromMap(Map<dynamic, dynamic>? map) {
+    if (map == null) return const FallbackSource();
+    final kind = map['kind'];
+    if (kind == 'network') return const NetworkSource();
+    if (kind == 'fallback') return const FallbackSource();
+    if (kind == 'persistence') {
+      final raw = map['persistedAtMillis'];
+      final millis = raw is int ? raw : (raw is num ? raw.toInt() : null);
+      if (millis == null) {
+        developer.log(
+            '`MixpanelFlagVariantSource.fromMap` received persistence source with missing persistedAtMillis, defaulting to fallback',
+            name: 'Mixpanel');
+        return const FallbackSource();
+      }
+      return PersistenceSource(
+          persistedAt: DateTime.fromMillisecondsSinceEpoch(millis));
+    }
+    return const FallbackSource();
+  }
+}
+
+/// The variant came from a fresh `/flags/` network response.
+class NetworkSource extends MixpanelFlagVariantSource {
+  const NetworkSource();
+
+  @override
+  String toString() => 'NetworkSource()';
+
+  @override
+  bool operator ==(Object other) => other is NetworkSource;
+
+  @override
+  int get hashCode => 0x4e57; // arbitrary stable constant for the singleton-ish case
+}
+
+/// The variant was loaded from the on-disk persistence layer.
+class PersistenceSource extends MixpanelFlagVariantSource {
+  /// Time the variant set was originally written to disk.
+  final DateTime persistedAt;
+
+  PersistenceSource({required this.persistedAt});
+
+  @override
+  String toString() => 'PersistenceSource(persistedAt: $persistedAt)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is PersistenceSource && other.persistedAt == persistedAt;
+
+  @override
+  int get hashCode => persistedAt.hashCode;
+}
+
+/// The SDK returned the developer-supplied fallback unchanged.
+class FallbackSource extends MixpanelFlagVariantSource {
+  const FallbackSource();
+
+  @override
+  String toString() => 'FallbackSource()';
+
+  @override
+  bool operator ==(Object other) => other is FallbackSource;
+
+  @override
+  int get hashCode => 0xfa11; // arbitrary stable constant for the singleton-ish case
+}
+
 /// Represents a feature flag variant with metadata.
 ///
 /// Contains the flag's key, value, and optional experiment-related metadata.
@@ -26,12 +117,31 @@ class MixpanelFlagVariant {
   /// Whether the current user is a QA tester.
   final bool? isQaTester;
 
+  /// Where this variant was sourced from. Non-null on every variant the SDK
+  /// returns. Variants the developer constructs default to [FallbackSource],
+  /// since the only reason to build one is to pass it as a fallback.
+  ///
+  /// Use `is` checks to distinguish:
+  ///
+  /// ```dart
+  /// final src = variant.source;
+  /// if (src is PersistenceSource) {
+  ///   print('persisted at ${src.persistedAt}');
+  /// } else if (src is NetworkSource) {
+  ///   print('fresh from /flags/');
+  /// } else if (src is FallbackSource) {
+  ///   print('developer-supplied fallback');
+  /// }
+  /// ```
+  final MixpanelFlagVariantSource source;
+
   MixpanelFlagVariant({
     required this.key,
     required this.value,
     this.experimentId,
     this.isExperimentActive,
     this.isQaTester,
+    this.source = const FallbackSource(),
   });
 
   /// Creates a MixpanelFlagVariant from a Map (used for platform channel deserialization).
@@ -48,6 +158,8 @@ class MixpanelFlagVariant {
       experimentId: map['experimentId'] as String?,
       isExperimentActive: map['isExperimentActive'] as bool?,
       isQaTester: map['isQaTester'] as bool?,
+      source: MixpanelFlagVariantSource.fromMap(
+          map['source'] as Map<dynamic, dynamic>?),
     );
   }
 
@@ -57,6 +169,10 @@ class MixpanelFlagVariant {
   }
 
   /// Converts this variant to a Map for serialization.
+  ///
+  /// Note: [source] is intentionally not serialized — it's a server/SDK-stamped
+  /// field, never set by callers, and the platform handlers don't consume it
+  /// from inbound fallbacks.
   Map<String, dynamic> toMap() {
     return {
       'key': key,
@@ -69,7 +185,7 @@ class MixpanelFlagVariant {
 
   @override
   String toString() {
-    return 'MixpanelFlagVariant(key: $key, value: $value, experimentId: $experimentId, isExperimentActive: $isExperimentActive, isQaTester: $isQaTester)';
+    return 'MixpanelFlagVariant(key: $key, value: $value, experimentId: $experimentId, isExperimentActive: $isExperimentActive, isQaTester: $isQaTester, source: $source)';
   }
 
   @override
@@ -80,7 +196,8 @@ class MixpanelFlagVariant {
         value == other.value &&
         experimentId == other.experimentId &&
         isExperimentActive == other.isExperimentActive &&
-        isQaTester == other.isQaTester;
+        isQaTester == other.isQaTester &&
+        source == other.source;
   }
 
   @override
@@ -92,8 +209,84 @@ class MixpanelFlagVariant {
     result = 37 * result + (experimentId?.hashCode ?? 0);
     result = 37 * result + (isExperimentActive?.hashCode ?? 0);
     result = 37 * result + (isQaTester?.hashCode ?? 0);
+    result = 37 * result + source.hashCode;
     return result;
   }
+}
+
+/// Strategy for resolving feature flag variants relative to the on-disk
+/// persistence layer and the network. Pass to
+/// [FeatureFlagsConfig.variantLookupPolicy] at init.
+///
+/// - [VariantLookupPolicy.networkOnly] (default): no persistence; variant
+///   lookups always wait for the network call. Any stale data from a prior
+///   session that used a persisting policy is wiped on init.
+/// - [VariantLookupPolicy.persistenceUntilNetworkSuccess]: serve persisted
+///   variants immediately on init (within
+///   [PersistenceUntilNetworkSuccessPolicy.ttl]), refresh from the network in
+///   the background.
+/// - [VariantLookupPolicy.networkFirst]: await the network call; only fall
+///   back to persisted variants (within [NetworkFirstPolicy.ttl]) if the
+///   network call fails.
+///
+/// Inspect [MixpanelFlagVariant.source] on a served variant to tell whether
+/// it came from persistence or a fresh network response.
+abstract class VariantLookupPolicy {
+  const VariantLookupPolicy();
+
+  /// No persistence. Variant lookups always wait for the network call.
+  /// Wipes any stale on-disk data from a prior session on init.
+  const factory VariantLookupPolicy.networkOnly() = NetworkOnlyPolicy;
+
+  /// Serve persisted variants immediately on init (within [ttl]), then
+  /// refresh from the network in the background.
+  const factory VariantLookupPolicy.persistenceUntilNetworkSuccess(
+      {Duration ttl}) = PersistenceUntilNetworkSuccessPolicy;
+
+  /// Await the network call; fall back to persisted variants (within [ttl])
+  /// only on network failure.
+  const factory VariantLookupPolicy.networkFirst({Duration ttl}) =
+      NetworkFirstPolicy;
+
+  /// Serializes this policy for the platform channel.
+  Map<String, dynamic> toMap();
+}
+
+/// Policy: never read or write the on-disk persistence layer. Default behavior.
+class NetworkOnlyPolicy extends VariantLookupPolicy {
+  const NetworkOnlyPolicy();
+
+  @override
+  Map<String, dynamic> toMap() => const {'policy': 'networkOnly'};
+}
+
+/// Policy: serve persisted variants immediately, refresh in the background.
+class PersistenceUntilNetworkSuccessPolicy extends VariantLookupPolicy {
+  /// Maximum age of a persisted variant set before it is ignored on read.
+  /// Defaults to 24 hours.
+  final Duration ttl;
+
+  const PersistenceUntilNetworkSuccessPolicy(
+      {this.ttl = const Duration(hours: 24)});
+
+  @override
+  Map<String, dynamic> toMap() => {
+        'policy': 'persistenceUntilNetworkSuccess',
+        'ttlMs': ttl.inMilliseconds,
+      };
+}
+
+/// Policy: prefer fresh network values, fall back to persistence only on failure.
+class NetworkFirstPolicy extends VariantLookupPolicy {
+  /// Maximum age of a persisted variant set before it is ignored on read.
+  /// Defaults to 24 hours.
+  final Duration ttl;
+
+  const NetworkFirstPolicy({this.ttl = const Duration(hours: 24)});
+
+  @override
+  Map<String, dynamic> toMap() =>
+      {'policy': 'networkFirst', 'ttlMs': ttl.inMilliseconds};
 }
 
 /// Configuration options for feature flags.
@@ -107,9 +300,15 @@ class FeatureFlagsConfig {
   /// These can be used for targeting and segmentation.
   final Map<String, dynamic> context;
 
-  FeatureFlagsConfig({
+  /// Strategy for resolving variants relative to the on-disk cache and
+  /// network. Defaults to [VariantLookupPolicy.networkOnly] — matches the
+  /// native SDK defaults and pre-persistence behavior.
+  final VariantLookupPolicy variantLookupPolicy;
+
+  const FeatureFlagsConfig({
     this.enabled = true,
     this.context = const {},
+    this.variantLookupPolicy = const VariantLookupPolicy.networkOnly(),
   });
 
   /// Converts this config to a Map for serialization.
@@ -117,6 +316,7 @@ class FeatureFlagsConfig {
     return {
       'enabled': enabled,
       'context': context,
+      'variantLookupPolicy': variantLookupPolicy.toMap(),
     };
   }
 }

--- a/lib/mixpanel_flutter.dart
+++ b/lib/mixpanel_flutter.dart
@@ -264,11 +264,6 @@ class NetworkOnlyPolicy extends VariantLookupPolicy {
 class PersistenceUntilNetworkSuccessPolicy extends VariantLookupPolicy {
   /// Maximum age of a persisted variant set before it is ignored on read.
   /// Defaults to 24 hours.
-  ///
-  /// Edge cases (handled by the native SDKs):
-  /// - [Duration.zero] — entries are always considered expired on every check.
-  /// - Negative durations — invalid; coerced to 24 hours and a warning is
-  ///   logged on the native side.
   final Duration ttl;
 
   const PersistenceUntilNetworkSuccessPolicy(
@@ -285,11 +280,6 @@ class PersistenceUntilNetworkSuccessPolicy extends VariantLookupPolicy {
 class NetworkFirstPolicy extends VariantLookupPolicy {
   /// Maximum age of a persisted variant set before it is ignored on read.
   /// Defaults to 24 hours.
-  ///
-  /// Edge cases (handled by the native SDKs):
-  /// - [Duration.zero] — entries are always considered expired on every check.
-  /// - Negative durations — invalid; coerced to 24 hours and a warning is
-  ///   logged on the native side.
   final Duration ttl;
 
   const NetworkFirstPolicy({this.ttl = const Duration(hours: 24)});

--- a/lib/mixpanel_flutter_web.dart
+++ b/lib/mixpanel_flutter_web.dart
@@ -632,36 +632,27 @@ class MixpanelFlutterPlugin {
     }
   }
 
-  /// Translates the web SDK's flat `variant_source` + `persisted_age_in_ms`
+  /// Translates the web SDK's flat `variant_source` + `persisted_at_in_ms`
   /// fields into the discriminated `{kind, persistedAtMillis?}` shape that the
   /// Dart wrapper expects (and that the iOS/Android handlers produce). Returns
   /// `{'kind': 'fallback'}` when `variant_source` is absent — i.e., the
   /// variant is the developer-supplied fallback.
   Map<String, dynamic> _jsSourceToMap(Map<Object?, Object?> variant) {
     final raw = variant['variant_source'];
-    // The JS SDK names this case 'cache'; we surface it to the Dart layer as
-    // 'persistence' to match the mobile clients' terminology.
-    if (raw == 'cache' || raw == 'persistence') {
-      final ageRaw = variant['persisted_age_in_ms'];
-      final ageMs = ageRaw is num ? ageRaw.toInt() : null;
-      // The web SDK only exposes age, not the absolute write time. Compute the
-      // approximate persistedAt from "now" so the Dart side sees a DateTime
-      // consistent with iOS/Android. Drift is bounded by the few ms between
-      // the SDK reading from persistence and us reading this map.
-      if (ageMs == null) {
-        debugPrint('[Mixpanel] persistence variant missing persisted_age_in_ms, defaulting to fallback');
+    if (raw == 'persistence') {
+      final atRaw = variant['persisted_at_in_ms'];
+      final atMs = atRaw is num ? atRaw.toInt() : null;
+      if (atMs == null) {
+        debugPrint('[Mixpanel] persistence variant missing persisted_at_in_ms, defaulting to fallback');
         return {'kind': 'fallback'};
       }
-      return {
-        'kind': 'persistence',
-        'persistedAtMillis': DateTime.now().millisecondsSinceEpoch - ageMs,
-      };
+      return {'kind': 'persistence', 'persistedAtMillis': atMs};
     }
     if (raw == 'network') {
       return {'kind': 'network'};
     }
-    // Missing variant_source (or unknown value) means the JS SDK returned the
-    // developer-supplied fallback unchanged.
+    // 'fallback', missing, or unknown — the JS SDK returned the developer-
+    // supplied fallback unchanged.
     return {'kind': 'fallback'};
   }
 
@@ -674,7 +665,8 @@ class MixpanelFlutterPlugin {
     if (policy == 'persistenceUntilNetworkSuccess' || policy == 'networkFirst') {
       return {
         'variantLookupPolicy': policy,
-        if (policyMap['ttlMs'] is num) 'ttlMs': policyMap['ttlMs'],
+        if (policyMap['persistenceTtlMillis'] is num)
+          'persistenceTtlMs': policyMap['persistenceTtlMillis'],
       };
     }
     // 'networkOnly' (or unknown) — let the JS SDK use its default.

--- a/lib/mixpanel_flutter_web.dart
+++ b/lib/mixpanel_flutter_web.dart
@@ -634,9 +634,13 @@ class MixpanelFlutterPlugin {
 
   /// Translates the web SDK's flat `variant_source` + `persisted_at_in_ms`
   /// fields into the discriminated `{kind, persistedAtMillis?}` shape that the
-  /// Dart wrapper expects (and that the iOS/Android handlers produce). Returns
-  /// `{'kind': 'fallback'}` when `variant_source` is absent — i.e., the
-  /// variant is the developer-supplied fallback.
+  /// Dart wrapper expects (and that the iOS/Android handlers produce). Defaults
+  /// to `{'kind': 'network'}` when `variant_source` is absent: at the time of
+  /// this release the Mixpanel JS SDK does not yet emit `variant_source`, so
+  /// every served variant lands here — treating them as network beats
+  /// mislabeling every successful fetch as a fallback. Sources will be
+  /// reported accurately once JS SDK support ships; check the Mixpanel JS
+  /// docs for availability.
   Map<String, dynamic> _jsSourceToMap(Map<Object?, Object?> variant) {
     final raw = variant['variant_source'];
     if (raw == 'persistence') {
@@ -648,12 +652,11 @@ class MixpanelFlutterPlugin {
       }
       return {'kind': 'persistence', 'persistedAtMillis': atMs};
     }
-    if (raw == 'network') {
-      return {'kind': 'network'};
+    if (raw == 'fallback') {
+      return {'kind': 'fallback'};
     }
-    // 'fallback', missing, or unknown — the JS SDK returned the developer-
-    // supplied fallback unchanged.
-    return {'kind': 'fallback'};
+    // 'network', missing, or unknown.
+    return {'kind': 'network'};
   }
 
   /// Translates the Dart-side [VariantLookupPolicy] wire format into the

--- a/lib/mixpanel_flutter_web.dart
+++ b/lib/mixpanel_flutter_web.dart
@@ -222,12 +222,17 @@ class MixpanelFlutterPlugin {
     if (featureFlags != null && featureFlags is Map) {
       bool enabled = featureFlags['enabled'] == true;
       if (enabled) {
+        final flagsConfig = <String, dynamic>{};
         dynamic context = featureFlags['context'];
         if (context != null && context is Map && context.isNotEmpty) {
-          initConfig['flags'] = {'context': context};
-        } else {
-          initConfig['flags'] = true;
+          flagsConfig['context'] = context;
         }
+        final persistence =
+            _flagsPersistenceFromPolicy(featureFlags['variantLookupPolicy']);
+        if (persistence != null) {
+          flagsConfig['persistence'] = persistence;
+        }
+        initConfig['flags'] = flagsConfig.isEmpty ? true : flagsConfig;
       }
     }
 
@@ -583,6 +588,7 @@ class MixpanelFlutterPlugin {
           'experimentId': value['experiment_id'] as String?,
           'isExperimentActive': value['is_experiment_active'] as bool?,
           'isQaTester': value['is_qa_tester'] as bool?,
+          'source': _jsSourceToMap(value),
         };
       }
     });
@@ -590,15 +596,18 @@ class MixpanelFlutterPlugin {
   }
 
   Map<String, dynamic> _jsVariantToMap(JSAny? jsResult, Map<Object?, Object?> fallbackMap) {
+    Map<String, dynamic> fallback() => {
+          'key': fallbackMap['key'] as String? ?? '',
+          'value': fallbackMap['value'],
+          'experimentId': null,
+          'isExperimentActive': null,
+          'isQaTester': null,
+          'source': const {'kind': 'fallback'},
+        };
+
     if (jsResult == null) {
       debugPrint('[Mixpanel] _jsVariantToMap received null result, returning fallback');
-      return {
-        'key': fallbackMap['key'] as String? ?? '',
-        'value': fallbackMap['value'],
-        'experimentId': null,
-        'isExperimentActive': null,
-        'isQaTester': null,
-      };
+      return fallback();
     }
 
     // Convert JS object to Dart map
@@ -606,13 +615,7 @@ class MixpanelFlutterPlugin {
       Map<Object?, Object?>? dartMap = (jsResult as JSObject).dartify() as Map<Object?, Object?>?;
       if (dartMap == null) {
         debugPrint('[Mixpanel] _jsVariantToMap failed to convert JS object, returning fallback');
-        return {
-          'key': fallbackMap['key'] as String? ?? '',
-          'value': fallbackMap['value'],
-          'experimentId': null,
-          'isExperimentActive': null,
-          'isQaTester': null,
-        };
+        return fallback();
       }
 
       return {
@@ -621,16 +624,60 @@ class MixpanelFlutterPlugin {
         'experimentId': dartMap['experiment_id'] as String?,
         'isExperimentActive': dartMap['is_experiment_active'] as bool?,
         'isQaTester': dartMap['is_qa_tester'] as bool?,
+        'source': _jsSourceToMap(dartMap),
       };
     } catch (e) {
       debugPrint('[Mixpanel] _jsVariantToMap failed with error: $e, returning fallback');
+      return fallback();
+    }
+  }
+
+  /// Translates the web SDK's flat `variant_source` + `persisted_age_in_ms`
+  /// fields into the discriminated `{kind, persistedAtMillis?}` shape that the
+  /// Dart wrapper expects (and that the iOS/Android handlers produce). Returns
+  /// `{'kind': 'fallback'}` when `variant_source` is absent — i.e., the
+  /// variant is the developer-supplied fallback.
+  Map<String, dynamic> _jsSourceToMap(Map<Object?, Object?> variant) {
+    final raw = variant['variant_source'];
+    // The JS SDK names this case 'cache'; we surface it to the Dart layer as
+    // 'persistence' to match the mobile clients' terminology.
+    if (raw == 'cache' || raw == 'persistence') {
+      final ageRaw = variant['persisted_age_in_ms'];
+      final ageMs = ageRaw is num ? ageRaw.toInt() : null;
+      // The web SDK only exposes age, not the absolute write time. Compute the
+      // approximate persistedAt from "now" so the Dart side sees a DateTime
+      // consistent with iOS/Android. Drift is bounded by the few ms between
+      // the SDK reading from persistence and us reading this map.
+      if (ageMs == null) {
+        debugPrint('[Mixpanel] persistence variant missing persisted_age_in_ms, defaulting to fallback');
+        return {'kind': 'fallback'};
+      }
       return {
-        'key': fallbackMap['key'] as String? ?? '',
-        'value': fallbackMap['value'],
-        'experimentId': null,
-        'isExperimentActive': null,
-        'isQaTester': null,
+        'kind': 'persistence',
+        'persistedAtMillis': DateTime.now().millisecondsSinceEpoch - ageMs,
       };
     }
+    if (raw == 'network') {
+      return {'kind': 'network'};
+    }
+    // Missing variant_source (or unknown value) means the JS SDK returned the
+    // developer-supplied fallback unchanged.
+    return {'kind': 'fallback'};
+  }
+
+  /// Translates the Dart-side [VariantLookupPolicy] wire format into the
+  /// `flags.persistence` config shape the web SDK accepts. Returns `null` for
+  /// the default `networkOnly` policy so we don't bloat the config.
+  Map<String, dynamic>? _flagsPersistenceFromPolicy(dynamic policyMap) {
+    if (policyMap is! Map) return null;
+    final policy = policyMap['policy'];
+    if (policy == 'persistenceUntilNetworkSuccess' || policy == 'networkFirst') {
+      return {
+        'variantLookupPolicy': policy,
+        if (policyMap['ttlMs'] is num) 'ttlMs': policyMap['ttlMs'],
+      };
+    }
+    // 'networkOnly' (or unknown) — let the JS SDK use its default.
+    return null;
   }
 }

--- a/macos/mixpanel_flutter.podspec
+++ b/macos/mixpanel_flutter.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
-  s.dependency 'Mixpanel-swift', '6.3.0'
+  s.dependency 'Mixpanel-swift', '6.4.0'
   s.platform = :osx, '10.15'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }

--- a/swift/Classes/SwiftMixpanelFlutterPlugin.swift
+++ b/swift/Classes/SwiftMixpanelFlutterPlugin.swift
@@ -741,22 +741,22 @@ public class SwiftMixpanelFlutterPlugin: NSObject, FlutterPlugin {
         case "networkOnly":
             return .networkOnly
         case "persistenceUntilNetworkSuccess":
-            return .persistenceUntilNetworkSuccess(ttl: readTtlSeconds(policyMap))
+            return .persistenceUntilNetworkSuccess(persistenceTtl: readPersistenceTtlSeconds(policyMap))
         case "networkFirst":
-            return .networkFirst(ttl: readTtlSeconds(policyMap))
+            return .networkFirst(persistenceTtl: readPersistenceTtlSeconds(policyMap))
         default:
             NSLog("[Mixpanel] Unknown variantLookupPolicy '\(kind)', falling back to networkOnly")
             return .networkOnly
         }
     }
 
-    private func readTtlSeconds(_ policyMap: [String: Any]) -> TimeInterval {
-        if let millis = policyMap["ttlMs"] as? NSNumber {
+    private func readPersistenceTtlSeconds(_ policyMap: [String: Any]) -> TimeInterval {
+        if let millis = policyMap["persistenceTtlMillis"] as? NSNumber {
             return TimeInterval(truncating: millis) / 1000.0
         }
         // Match the Dart-side default (24 hours). Should never hit this path in
-        // practice — the Dart layer always serializes ttlMs for non-networkOnly
-        // policies — but keep this in sync to stay safe.
+        // practice — the Dart layer always serializes persistenceTtlMillis for
+        // non-networkOnly policies — but keep this in sync to stay safe.
         return 24 * 60 * 60
     }
 

--- a/swift/Classes/SwiftMixpanelFlutterPlugin.swift
+++ b/swift/Classes/SwiftMixpanelFlutterPlugin.swift
@@ -194,12 +194,16 @@ public class SwiftMixpanelFlutterPlugin: NSObject, FlutterPlugin {
         let trackAutomaticEvents = arguments["trackAutomaticEvents"] as! Bool
 
         // Check for feature flags configuration
-        var featureFlagsEnabled = false
-        var featureFlagsContext: [String: Any] = [:]
+        var featureFlagOptions: FeatureFlagOptions? = nil
         if let featureFlags = arguments["featureFlags"] as? [String: Any],
            let enabled = featureFlags["enabled"] as? Bool, enabled {
-            featureFlagsEnabled = true
-            featureFlagsContext = featureFlags["context"] as? [String: Any] ?? [:]
+            let context = featureFlags["context"] as? [String: Any] ?? [:]
+            let policy = parseVariantLookupPolicy(featureFlags["variantLookupPolicy"] as? [String: Any])
+            featureFlagOptions = FeatureFlagOptions(
+                enabled: true,
+                context: context,
+                variantLookupPolicy: policy
+            )
         }
 
         let options = MixpanelOptions(
@@ -209,8 +213,7 @@ public class SwiftMixpanelFlutterPlugin: NSObject, FlutterPlugin {
             trackAutomaticEvents: trackAutomaticEvents,
             optOutTrackingByDefault: optOutTrackingDefault ?? false,
             superProperties: MixpanelTypeHandler.mixpanelProperties(properties: superProperties, mixpanelProperties: mixpanelProperties),
-            featureFlagsEnabled: featureFlagsEnabled,
-            featureFlagsContext: featureFlagsContext
+            featureFlagOptions: featureFlagOptions
         )
         instance = Mixpanel.initialize(options: options)
 
@@ -707,8 +710,54 @@ public class SwiftMixpanelFlutterPlugin: NSObject, FlutterPlugin {
             "value": variant.value ?? NSNull(),
             "experimentId": variant.experimentID ?? NSNull(),
             "isExperimentActive": variant.isExperimentActive ?? NSNull(),
-            "isQaTester": variant.isQATester ?? NSNull()
+            "isQaTester": variant.isQATester ?? NSNull(),
+            "source": flagVariantSourceToMap(variant.source) ?? NSNull()
         ]
+    }
+
+    private func flagVariantSourceToMap(_ source: MixpanelFlagVariant.Source?) -> [String: Any]? {
+        // Native source is non-nil on every variant the SDK returns. Defensive
+        // nil-check kept in case the bridge runs against an older native build
+        // that still allowed nil sources.
+        guard let source = source else { return nil }
+        switch source {
+        case .network:
+            return ["kind": "network"]
+        case .persistence(let persistedAt):
+            return [
+                "kind": "persistence",
+                "persistedAtMillis": Int64(persistedAt.timeIntervalSince1970 * 1000)
+            ]
+        case .fallback:
+            return ["kind": "fallback"]
+        }
+    }
+
+    private func parseVariantLookupPolicy(_ policyMap: [String: Any]?) -> VariantLookupPolicy {
+        guard let policyMap = policyMap, let kind = policyMap["policy"] as? String else {
+            return .networkOnly
+        }
+        switch kind {
+        case "networkOnly":
+            return .networkOnly
+        case "persistenceUntilNetworkSuccess":
+            return .persistenceUntilNetworkSuccess(ttl: readTtlSeconds(policyMap))
+        case "networkFirst":
+            return .networkFirst(ttl: readTtlSeconds(policyMap))
+        default:
+            NSLog("[Mixpanel] Unknown variantLookupPolicy '\(kind)', falling back to networkOnly")
+            return .networkOnly
+        }
+    }
+
+    private func readTtlSeconds(_ policyMap: [String: Any]) -> TimeInterval {
+        if let millis = policyMap["ttlMs"] as? NSNumber {
+            return TimeInterval(truncating: millis) / 1000.0
+        }
+        // Match the Dart-side default (24 hours). Should never hit this path in
+        // practice — the Dart layer always serializes ttlMs for non-networkOnly
+        // policies — but keep this in sync to stay safe.
+        return 24 * 60 * 60
     }
 
 }

--- a/test/mixpanel_flutter_test.dart
+++ b/test/mixpanel_flutter_test.dart
@@ -1179,6 +1179,7 @@ void main() {
             'featureFlags': {
               'enabled': true,
               'context': {'user_tier': 'premium'},
+              'variantLookupPolicy': {'policy': 'networkOnly'},
             },
           },
         ),
@@ -1209,6 +1210,7 @@ void main() {
             'featureFlags': {
               'enabled': true,
               'context': <String, dynamic>{},
+              'variantLookupPolicy': {'policy': 'networkOnly'},
             },
           },
         ),
@@ -1242,6 +1244,7 @@ void main() {
             'featureFlags': {
               'enabled': false,
               'context': {'user_tier': 'premium'},
+              'variantLookupPolicy': {'policy': 'networkOnly'},
             },
           },
         ),
@@ -1289,16 +1292,148 @@ void main() {
       final map = config.toMap();
       expect(map['enabled'], true);
       expect(map['context'], {'key': 'value'});
+      expect(map['variantLookupPolicy'], {'policy': 'networkOnly'});
     });
 
     test('FeatureFlagsConfig default values', () {
       final config = FeatureFlagsConfig();
       expect(config.enabled, true);
       expect(config.context, <String, dynamic>{});
+      expect(config.variantLookupPolicy, isA<NetworkOnlyPolicy>());
 
       final map = config.toMap();
       expect(map['enabled'], true);
       expect(map['context'], <String, dynamic>{});
+      expect(map['variantLookupPolicy'], {'policy': 'networkOnly'});
+    });
+
+    test('VariantLookupPolicy.persistenceUntilNetworkSuccess serializes ttlMs',
+        () {
+      const policy = VariantLookupPolicy.persistenceUntilNetworkSuccess(
+          ttl: Duration(hours: 24));
+      expect(policy, isA<PersistenceUntilNetworkSuccessPolicy>());
+      expect(policy.toMap(), {
+        'policy': 'persistenceUntilNetworkSuccess',
+        'ttlMs': const Duration(hours: 24).inMilliseconds,
+      });
+    });
+
+    test(
+        'VariantLookupPolicy.persistenceUntilNetworkSuccess defaults ttl to 24 hours',
+        () {
+      const policy = VariantLookupPolicy.persistenceUntilNetworkSuccess();
+      expect((policy as PersistenceUntilNetworkSuccessPolicy).ttl,
+          const Duration(hours: 24));
+      expect(policy.toMap()['ttlMs'], const Duration(hours: 24).inMilliseconds);
+    });
+
+    test('VariantLookupPolicy.networkFirst serializes ttlMs', () {
+      const policy =
+          VariantLookupPolicy.networkFirst(ttl: Duration(minutes: 30));
+      expect(policy, isA<NetworkFirstPolicy>());
+      expect(policy.toMap(), {
+        'policy': 'networkFirst',
+        'ttlMs': const Duration(minutes: 30).inMilliseconds,
+      });
+    });
+
+    test('VariantLookupPolicy.networkFirst defaults ttl to 24 hours', () {
+      const policy = VariantLookupPolicy.networkFirst();
+      expect((policy as NetworkFirstPolicy).ttl, const Duration(hours: 24));
+    });
+
+    test(
+        'FeatureFlagsConfig forwards persistenceUntilNetworkSuccess policy through init',
+        () async {
+      _mixpanel = await Mixpanel.init(
+        "test token",
+        optOutTrackingDefault: false,
+        trackAutomaticEvents: true,
+        featureFlags: const FeatureFlagsConfig(
+          enabled: true,
+          variantLookupPolicy: VariantLookupPolicy.persistenceUntilNetworkSuccess(
+              ttl: Duration(hours: 6)),
+        ),
+      );
+      final args = (methodCall!.arguments as Map)['featureFlags'] as Map;
+      expect(args['variantLookupPolicy'], {
+        'policy': 'persistenceUntilNetworkSuccess',
+        'ttlMs': const Duration(hours: 6).inMilliseconds,
+      });
+    });
+
+    test('MixpanelFlagVariant.fromMap parses persistence source', () {
+      final variant = MixpanelFlagVariant.fromMap({
+        'key': 'flag_a',
+        'value': 'on',
+        'source': {'kind': 'persistence', 'persistedAtMillis': 1700000000000},
+      });
+      expect(variant.source, isA<PersistenceSource>());
+      final src = variant.source as PersistenceSource;
+      expect(src.persistedAt,
+          DateTime.fromMillisecondsSinceEpoch(1700000000000));
+    });
+
+    test('MixpanelFlagVariant.fromMap parses network source', () {
+      final variant = MixpanelFlagVariant.fromMap({
+        'key': 'flag_a',
+        'value': 'on',
+        'source': {'kind': 'network'},
+      });
+      expect(variant.source, isA<NetworkSource>());
+    });
+
+    test('MixpanelFlagVariant.fromMap defaults source to FallbackSource when absent',
+        () {
+      final variant = MixpanelFlagVariant.fromMap({
+        'key': 'flag_a',
+        'value': 'on',
+      });
+      expect(variant.source, isA<FallbackSource>());
+    });
+
+    test('MixpanelFlagVariant.fromMap parses fallback source', () {
+      final variant = MixpanelFlagVariant.fromMap({
+        'key': 'flag_a',
+        'value': 'on',
+        'source': {'kind': 'fallback'},
+      });
+      expect(variant.source, isA<FallbackSource>());
+    });
+
+    test(
+        'MixpanelFlagVariant.fromMap defaults to FallbackSource when persistence source missing timestamp',
+        () {
+      final variant = MixpanelFlagVariant.fromMap({
+        'key': 'flag_a',
+        'value': 'on',
+        'source': {'kind': 'persistence'},
+      });
+      expect(variant.source, isA<FallbackSource>());
+    });
+
+    test('MixpanelFlagVariant.fallback factory has FallbackSource', () {
+      final variant = MixpanelFlagVariant.fallback('flag_a', 'control');
+      expect(variant.source, isA<FallbackSource>());
+    });
+
+    test('FallbackSource instances are equal', () {
+      expect(const FallbackSource(), const FallbackSource());
+    });
+
+    test('PersistenceSource equality uses persistedAt', () {
+      final t = DateTime.fromMillisecondsSinceEpoch(1700000000000);
+      expect(PersistenceSource(persistedAt: t),
+          PersistenceSource(persistedAt: t));
+      expect(
+          PersistenceSource(persistedAt: t),
+          isNot(PersistenceSource(
+              persistedAt:
+                  DateTime.fromMillisecondsSinceEpoch(1700000000001))));
+    });
+
+    test('NetworkSource instances are equal', () {
+      expect(const NetworkSource(), const NetworkSource());
     });
 
     test('areFlagsReady returns false when not ready', () async {

--- a/test/mixpanel_flutter_test.dart
+++ b/test/mixpanel_flutter_test.dart
@@ -1307,39 +1307,44 @@ void main() {
       expect(map['variantLookupPolicy'], {'policy': 'networkOnly'});
     });
 
-    test('VariantLookupPolicy.persistenceUntilNetworkSuccess serializes ttlMs',
+    test(
+        'VariantLookupPolicy.persistenceUntilNetworkSuccess serializes persistenceTtlMillis',
         () {
       const policy = VariantLookupPolicy.persistenceUntilNetworkSuccess(
-          ttl: Duration(hours: 24));
+          persistenceTtl: Duration(hours: 24));
       expect(policy, isA<PersistenceUntilNetworkSuccessPolicy>());
       expect(policy.toMap(), {
         'policy': 'persistenceUntilNetworkSuccess',
-        'ttlMs': const Duration(hours: 24).inMilliseconds,
+        'persistenceTtlMillis': const Duration(hours: 24).inMilliseconds,
       });
     });
 
     test(
-        'VariantLookupPolicy.persistenceUntilNetworkSuccess defaults ttl to 24 hours',
+        'VariantLookupPolicy.persistenceUntilNetworkSuccess defaults persistenceTtl to 24 hours',
         () {
       const policy = VariantLookupPolicy.persistenceUntilNetworkSuccess();
-      expect((policy as PersistenceUntilNetworkSuccessPolicy).ttl,
+      expect((policy as PersistenceUntilNetworkSuccessPolicy).persistenceTtl,
           const Duration(hours: 24));
-      expect(policy.toMap()['ttlMs'], const Duration(hours: 24).inMilliseconds);
+      expect(policy.toMap()['persistenceTtlMillis'],
+          const Duration(hours: 24).inMilliseconds);
     });
 
-    test('VariantLookupPolicy.networkFirst serializes ttlMs', () {
+    test('VariantLookupPolicy.networkFirst serializes persistenceTtlMillis',
+        () {
       const policy =
-          VariantLookupPolicy.networkFirst(ttl: Duration(minutes: 30));
+          VariantLookupPolicy.networkFirst(persistenceTtl: Duration(minutes: 30));
       expect(policy, isA<NetworkFirstPolicy>());
       expect(policy.toMap(), {
         'policy': 'networkFirst',
-        'ttlMs': const Duration(minutes: 30).inMilliseconds,
+        'persistenceTtlMillis': const Duration(minutes: 30).inMilliseconds,
       });
     });
 
-    test('VariantLookupPolicy.networkFirst defaults ttl to 24 hours', () {
+    test('VariantLookupPolicy.networkFirst defaults persistenceTtl to 24 hours',
+        () {
       const policy = VariantLookupPolicy.networkFirst();
-      expect((policy as NetworkFirstPolicy).ttl, const Duration(hours: 24));
+      expect((policy as NetworkFirstPolicy).persistenceTtl,
+          const Duration(hours: 24));
     });
 
     test(
@@ -1352,13 +1357,13 @@ void main() {
         featureFlags: const FeatureFlagsConfig(
           enabled: true,
           variantLookupPolicy: VariantLookupPolicy.persistenceUntilNetworkSuccess(
-              ttl: Duration(hours: 6)),
+              persistenceTtl: Duration(hours: 6)),
         ),
       );
       final args = (methodCall!.arguments as Map)['featureFlags'] as Map;
       expect(args['variantLookupPolicy'], {
         'policy': 'persistenceUntilNetworkSuccess',
-        'ttlMs': const Duration(hours: 6).inMilliseconds,
+        'persistenceTtlMillis': const Duration(hours: 6).inMilliseconds,
       });
     });
 


### PR DESCRIPTION
The Flutter SDK is an adapter on top of the native Android, iOS, macOS, and mixpanel-js bindings. The Dart-facing API mirrors the natives and forwards a normalized policy + source representation across the platform channel; each platform handler translates to/from its underlying SDK.

## Configuration types

### `VariantLookupPolicy`

Dart 2.12 doesn't have sealed classes, so the discriminated union uses an abstract base + concrete subclasses with const factory redirects. TTL uses `Duration`, idiomatic in Dart.

```dart
abstract class VariantLookupPolicy {
  const VariantLookupPolicy();

  const factory VariantLookupPolicy.networkOnly() = NetworkOnlyPolicy;
  const factory VariantLookupPolicy.persistenceUntilNetworkSuccess({Duration persistenceTtl}) = PersistenceUntilNetworkSuccessPolicy;
  const factory VariantLookupPolicy.networkFirst({Duration persistenceTtl}) = NetworkFirstPolicy;
}

class NetworkOnlyPolicy extends VariantLookupPolicy { ... }
class PersistenceUntilNetworkSuccessPolicy extends VariantLookupPolicy {
  final Duration persistenceTtl; // defaults to Duration(hours: 24)
  ...
}
class NetworkFirstPolicy extends VariantLookupPolicy {
  final Duration persistenceTtl; // defaults to Duration(hours: 24)
  ...
}
```

### `FeatureFlagsConfig` — new field

```dart
class FeatureFlagsConfig {
  final bool enabled;
  final Map<String, dynamic> context;
  final VariantLookupPolicy variantLookupPolicy; // default: VariantLookupPolicy.networkOnly()
}
```

Persistence behavior is derived directly from the policy

- `VariantLookupPolicy.networkOnly()` — no persistence. The on-disk blob is also wiped on init if present, so toggling from a persisting policy back to `networkOnly()` cleans up after itself.
- `VariantLookupPolicy.persistenceUntilNetworkSuccess(persistenceTtl: …)` / `VariantLookupPolicy.networkFirst(persistenceTtl: …)` — successful fetches write to disk; the cache is read on init. `persistenceTtl` defaults to `Duration(hours: 24)`.

### Web platform note

At the time of this release, the Mixpanel JS SDK does not yet support variant persistence. On web, both `persistenceUntilNetworkSuccess` and `networkFirst` are silently treated as `networkOnly`. Once the JS SDK ships persistence support (the wire format is already aligned), existing Flutter apps will pick it up automatically on their next page load with no plugin update required. Check the Mixpanel JS docs for availability.

### `MixpanelFlagVariantSource`

Discriminated via the new `MixpanelFlagVariant.source` field, which is non-null on every variant.

```dart
abstract class MixpanelFlagVariantSource {
  const factory MixpanelFlagVariantSource.network() = NetworkSource;
  factory MixpanelFlagVariantSource.persistence({required DateTime persistedAt}) = PersistenceSource;
  const factory MixpanelFlagVariantSource.fallback() = FallbackSource;
}

class NetworkSource extends MixpanelFlagVariantSource { ... }
class PersistenceSource extends MixpanelFlagVariantSource {
  final DateTime persistedAt; // when the variant set was originally written to disk
}
class FallbackSource extends MixpanelFlagVariantSource { ... }
```

Variants the developer constructs default to `FallbackSource`, since the only reason to build one directly is to pass it as a fallback. The SDK never independently stamps `FallbackSource` — it just returns the developer's variant unchanged.

## Behavior matrix

Identical to the underlying native SDK behavior; the Flutter bridge does not add or alter caching semantics.

variantLookupPolicy | Cache writes | Cache reads on init | Async lookup | Sync lookup / areFlagsReady()
-- | -- | -- | -- | --
VariantLookupPolicy.networkOnly() | no | no (and wipes any stale blob from a prior persisting session) | network only (today's behavior) | as today
VariantLookupPolicy.persistenceUntilNetworkSuccess(persistenceTtl: …) | yes | yes | serve persisted immediately, refresh in background | reflects persistence
VariantLookupPolicy.networkFirst(persistenceTtl: …) | yes | yes | await network; on failure serve persisted | reflects persistence


## Customer usage examples

### Default (no persistence — current behavior, no opt-in needed)

```dart
final mixpanel = await Mixpanel.init(
  TOKEN,
  trackAutomaticEvents: true,
  featureFlags: FeatureFlagsConfig(enabled: true),
);
```

### PersistenceUntilNetworkSuccess — consistency-across-sessions over freshness

Serves persisted variants immediately on app start (within TTL), refreshes from network in the background.

```dart
final mixpanel = await Mixpanel.init(
  TOKEN,
  trackAutomaticEvents: true,
  featureFlags: FeatureFlagsConfig(
    enabled: true,
    variantLookupPolicy: VariantLookupPolicy.persistenceUntilNetworkSuccess(
      persistenceTtl: Duration(hours: 24),
    ),
  ),
);
```

### NetworkFirst — freshness with offline resilience

Async lookups await the network call; only fall back to persisted variants if it fails.

```dart
final mixpanel = await Mixpanel.init(
  TOKEN,
  trackAutomaticEvents: true,
  featureFlags: FeatureFlagsConfig(
    enabled: true,
    variantLookupPolicy: VariantLookupPolicy.networkFirst(
      persistenceTtl: Duration(hours: 24),
    ),
  ),
);
```

### Inspecting where a served variant came from

`variant.source` is non-null on every variant the SDK returns — `NetworkSource` and `PersistenceSource` mean the SDK found a real variant, `FallbackSource` means it returned the developer's fallback. Use `is` checks for type-safe pattern matching:

```dart
final fallback = MixpanelFlagVariant.fallback('checkout-experiment', 'control');
final variant = await mixpanel.getFeatureFlags()
    .getVariant('checkout-experiment', fallback);

final src = variant.source;
if (src is PersistenceSource) {
  print('Served from persistence, written at ${src.persistedAt}');
} else if (src is NetworkSource) {
  print('Served from a fresh /flags/ response');
} else if (src is FallbackSource) {
  print('Served the developer-supplied fallback');
}
```

### Sync lookups and `areFlagsReady()`

Flutter does not currently expose synchronous lookup methods — all `FeatureFlags` methods return `Future<…>`. `areFlagsReady()` is async (it round-trips through the platform channel) and reflects persisted values when a persisting policy is configured. Check `variant.source` if you need to distinguish between persisted and fresh values.

```dart
if (await mixpanel.getFeatureFlags().areFlagsReady()) {
  final variant = await mixpanel.getFeatureFlags()
      .getVariant('flag-name', fallback);
  // variant.source is NetworkSource, PersistenceSource, or FallbackSource
}
```