### PR TITLE
fix(analytics): bump minimum deployment target to 13.0 to match Mixpanel-swift 6.x

### DIFF
--- a/packages/mixpanel_flutter/ios/mixpanel_flutter.podspec
+++ b/packages/mixpanel_flutter/ios/mixpanel_flutter.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.dependency 'Mixpanel-swift', '6.4.0'
-  s.platform = :ios, '12.0'
+  s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
## Problem

`Mixpanel-swift` 6.x requires iOS 13.0 as minimum deployment target. The podspec still declared `12.0`, causing CocoaPods to error during `pod install`:

```
Error: The pod "Mixpanel-swift" required by the plugin "mixpanel_flutter" requires
a higher minimum iOS deployment version than the plugin's reported minimum version.
To build, remove the plugin "mixpanel_flutter", or contact the plugin's developers
for assistance.
Error running pod install
```

## Fix

Bump `s.platform = :ios, '13.0'` in `ios/mixpanel_flutter.podspec` to match the actual minimum required by `Mixpanel-swift` 6.x.

## Notes

- iOS 13.0 is a reasonable minimum in 2025 (99%+ of active devices)
- This aligns the declared minimum with what `Mixpanel-swift` already requires transitively