### PR TITLE
feat(analytics): expose serverURL in Mixpanel.init()

### DIFF
--- a/packages/mixpanel_flutter/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
+++ b/packages/mixpanel_flutter/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
@@ -239,6 +239,7 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
 
         Boolean optOutTrackingDefault = call.<Boolean>argument("optOutTrackingDefault");
         Boolean trackAutomaticEvents = call.<Boolean>argument("trackAutomaticEvents");
+        String serverURL = call.<String>argument("serverURL");
 
         // Parse feature flags config if provided
         Map<String, Object> featureFlagsMap = call.<HashMap<String, Object>>argument("featureFlags");
@@ -272,6 +273,10 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
         MixpanelOptions.Builder optionsBuilder = new MixpanelOptions.Builder()
                 .optOutTrackingDefault(optOutTrackingDefault == null ? false : optOutTrackingDefault)
                 .superProperties(superAndMixpanelProperties);
+
+        if (serverURL != null && !serverURL.isEmpty()) {
+            optionsBuilder.serverURL(serverURL);
+        }
 
         if (featureFlagsEnabled != null && featureFlagsEnabled) {
             FeatureFlagOptions.Builder ffBuilder = new FeatureFlagOptions.Builder().enabled(true);

--- a/packages/mixpanel_flutter/lib/mixpanel_flutter.dart
+++ b/packages/mixpanel_flutter/lib/mixpanel_flutter.dart
@@ -364,13 +364,17 @@ class Mixpanel {
   ///  * [superProperties] Optional super properties to register
   ///  * [config] Optional A dictionary of config options to override (WEB ONLY)
   ///  * [featureFlags] Optional Feature flags configuration
+  ///  * [serverURL] Optional base URL used for Mixpanel API requests. Useful if you
+  ///  need to proxy Mixpanel requests, or to route data to Mixpanel's EU servers
+  ///  (`https://api-eu.mixpanel.com`). Defaults to `https://api.mixpanel.com`.
   ///
   static Future<Mixpanel> init(String token,
       {bool optOutTrackingDefault = false,
       required bool trackAutomaticEvents,
       Map<String, dynamic>? superProperties,
       Map<String, dynamic>? config,
-      FeatureFlagsConfig? featureFlags}) async {
+      FeatureFlagsConfig? featureFlags,
+      String? serverURL}) async {
     var allProperties = <String, dynamic>{'token': token};
     allProperties['optOutTrackingDefault'] = optOutTrackingDefault;
     allProperties['trackAutomaticEvents'] = trackAutomaticEvents;
@@ -379,6 +383,9 @@ class Mixpanel {
     allProperties['config'] = _MixpanelHelper.ensureSerializableProperties(config);
     if (featureFlags != null) {
       allProperties['featureFlags'] = featureFlags.toMap();
+    }
+    if (serverURL != null && _MixpanelHelper.isValidString(serverURL)) {
+      allProperties['serverURL'] = serverURL;
     }
     await _channel.invokeMethod<void>('initialize', allProperties);
     return Mixpanel(token);

--- a/packages/mixpanel_flutter/lib/mixpanel_flutter_web.dart
+++ b/packages/mixpanel_flutter/lib/mixpanel_flutter_web.dart
@@ -218,6 +218,11 @@ class MixpanelFlutterPlugin {
     dynamic config = args['config'];
     Map<String, dynamic> initConfig = Map<String, dynamic>.from(config ?? {});
 
+    final serverURL = args['serverURL'];
+    if (serverURL is String && serverURL.isNotEmpty) {
+      initConfig['api_host'] = serverURL;
+    }
+
     // Handle feature flags configuration
     dynamic featureFlags = args['featureFlags'];
     if (featureFlags != null && featureFlags is Map) {

--- a/packages/mixpanel_flutter/swift/Classes/SwiftMixpanelFlutterPlugin.swift
+++ b/packages/mixpanel_flutter/swift/Classes/SwiftMixpanelFlutterPlugin.swift
@@ -192,8 +192,7 @@ public class SwiftMixpanelFlutterPlugin: NSObject, FlutterPlugin {
         let superProperties = arguments["superProperties"] as? [String: Any]
         self.token = token
         let trackAutomaticEvents = arguments["trackAutomaticEvents"] as! Bool
-        let serverURLArg = arguments["serverURL"] as? String
-        let serverURL = (serverURLArg != nil && !serverURLArg!.isEmpty) ? serverURLArg : nil
+        let serverURL = (arguments["serverURL"] as? String).flatMap { $0.isEmpty ? nil : $0 }
 
         // Check for feature flags configuration
         var featureFlagOptions: FeatureFlagOptions? = nil

--- a/packages/mixpanel_flutter/swift/Classes/SwiftMixpanelFlutterPlugin.swift
+++ b/packages/mixpanel_flutter/swift/Classes/SwiftMixpanelFlutterPlugin.swift
@@ -192,6 +192,8 @@ public class SwiftMixpanelFlutterPlugin: NSObject, FlutterPlugin {
         let superProperties = arguments["superProperties"] as? [String: Any]
         self.token = token
         let trackAutomaticEvents = arguments["trackAutomaticEvents"] as! Bool
+        let serverURLArg = arguments["serverURL"] as? String
+        let serverURL = (serverURLArg != nil && !serverURLArg!.isEmpty) ? serverURLArg : nil
 
         // Check for feature flags configuration
         var featureFlagOptions: FeatureFlagOptions? = nil
@@ -213,6 +215,7 @@ public class SwiftMixpanelFlutterPlugin: NSObject, FlutterPlugin {
             trackAutomaticEvents: trackAutomaticEvents,
             optOutTrackingByDefault: optOutTrackingDefault ?? false,
             superProperties: MixpanelTypeHandler.mixpanelProperties(properties: superProperties, mixpanelProperties: mixpanelProperties),
+            serverURL: serverURL,
             featureFlagOptions: featureFlagOptions
         )
         instance = Mixpanel.initialize(options: options)

--- a/packages/mixpanel_flutter/test/mixpanel_flutter_test.dart
+++ b/packages/mixpanel_flutter/test/mixpanel_flutter_test.dart
@@ -97,6 +97,59 @@ void main() {
     });
 
 
+    test('check initialize with serverURL forwards to native', () async {
+      _mixpanel = await Mixpanel.init(
+        "test token",
+        optOutTrackingDefault: false,
+        trackAutomaticEvents: true,
+        serverURL: 'https://api-eu.mixpanel.com',
+      );
+      expect(
+        methodCall,
+        isMethodCall(
+          'initialize',
+          arguments: <String, dynamic>{
+            'token': "test token",
+            'optOutTrackingDefault': false,
+            'trackAutomaticEvents': true,
+            'mixpanelProperties': {
+              '\$lib_version': sdkVersion,
+              'mp_lib': 'flutter',
+            },
+            'superProperties': null,
+            'config': null,
+            'serverURL': 'https://api-eu.mixpanel.com',
+          },
+        ),
+      );
+    });
+
+    test('check initialize omits serverURL when blank', () async {
+      _mixpanel = await Mixpanel.init(
+        "test token",
+        optOutTrackingDefault: false,
+        trackAutomaticEvents: true,
+        serverURL: '',
+      );
+      expect(
+        methodCall,
+        isMethodCall(
+          'initialize',
+          arguments: <String, dynamic>{
+            'token': "test token",
+            'optOutTrackingDefault': false,
+            'trackAutomaticEvents': true,
+            'mixpanelProperties': {
+              '\$lib_version': sdkVersion,
+              'mp_lib': 'flutter',
+            },
+            'superProperties': null,
+            'config': null,
+          },
+        ),
+      );
+    });
+
     test('check setServerURL', () async {
       _mixpanel.setServerURL("https://api-eu.mixpanel.com");
       expect(

--- a/packages/mixpanel_flutter/test/mixpanel_flutter_test.dart
+++ b/packages/mixpanel_flutter/test/mixpanel_flutter_test.dart
@@ -150,6 +150,32 @@ void main() {
       );
     });
 
+    test('check initialize omits serverURL when null', () async {
+      _mixpanel = await Mixpanel.init(
+        "test token",
+        optOutTrackingDefault: false,
+        trackAutomaticEvents: true,
+        serverURL: null,
+      );
+      expect(
+        methodCall,
+        isMethodCall(
+          'initialize',
+          arguments: <String, dynamic>{
+            'token': "test token",
+            'optOutTrackingDefault': false,
+            'trackAutomaticEvents': true,
+            'mixpanelProperties': {
+              '\$lib_version': sdkVersion,
+              'mp_lib': 'flutter',
+            },
+            'superProperties': null,
+            'config': null,
+          },
+        ),
+      );
+    });
+
     test('check setServerURL', () async {
       _mixpanel.setServerURL("https://api-eu.mixpanel.com");
       expect(


### PR DESCRIPTION
Adds an optional `serverURL` named parameter on `Mixpanel.init()` and forwards it to the native iOS, Android, macOS, and web SDKs at initialization time. Lets callers pin a proxy host or the EU endpoint without making a separate setServerURL call after init.