### PR TITLE
fix(session-replay): drop redundant -flutter suffix from sdkVersion

### DIFF
--- a/packages/mixpanel_flutter_session_replay/lib/src/version.dart
+++ b/packages/mixpanel_flutter_session_replay/lib/src/version.dart
@@ -1,7 +1,7 @@
 import 'dart:io' show Platform;
 
 /// SDK version constant. Update this alongside pubspec.yaml when releasing.
-const String sdkVersion = '1.0.0-flutter';
+const String sdkVersion = '1.0.0';
 
 /// Operating system name for query parameters ($os).
 /// Computed once at startup since it never changes.

--- a/packages/mixpanel_flutter_session_replay/test/payload_serializer_test.dart
+++ b/packages/mixpanel_flutter_session_replay/test/payload_serializer_test.dart
@@ -6,6 +6,7 @@ import 'package:clock/clock.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mixpanel_flutter_session_replay/src/internal/upload/payload_serializer.dart';
+import 'package:mixpanel_flutter_session_replay/src/version.dart';
 import 'package:mixpanel_flutter_session_replay/src/models/session.dart';
 import 'package:mixpanel_flutter_session_replay/src/models/session_event.dart';
 import 'package:mixpanel_flutter_session_replay/src/models/rrweb_types.dart';
@@ -305,7 +306,7 @@ void main() {
         expect(params['distinct_id'], expectedDistinctId);
         expect(params['seq'], expectedSequenceNumber);
         expect(params['replay_id'], expectedSessionId);
-        expect(params['\$lib_version'], endsWith('-flutter'));
+        expect(params['\$lib_version'], sdkVersion);
       });
 
       test('includes dynamic timestamp parameters', () {

--- a/packages/mixpanel_flutter_session_replay/test/settings_service_test.dart
+++ b/packages/mixpanel_flutter_session_replay/test/settings_service_test.dart
@@ -8,6 +8,7 @@ import 'package:http/testing.dart' as http_testing;
 import 'package:mixpanel_flutter_session_replay/src/internal/settings/settings_service.dart';
 import 'package:mixpanel_flutter_session_replay/src/internal/settings/settings_storage_provider.dart';
 import 'package:mixpanel_flutter_session_replay/src/internal/logger.dart';
+import 'package:mixpanel_flutter_session_replay/src/version.dart';
 import 'package:mixpanel_flutter_session_replay/src/models/configuration.dart';
 import 'package:mixpanel_flutter_session_replay/src/models/event_trigger.dart';
 
@@ -585,7 +586,7 @@ void main() {
       expect(uri.queryParameters['recording'], '1');
       expect(uri.queryParameters['sdk_config'], '1');
       expect(uri.queryParameters['mp_lib'], 'flutter-sr');
-      expect(uri.queryParameters['\$lib_version'], endsWith('-flutter'));
+      expect(uri.queryParameters['\$lib_version'], sdkVersion);
       expect(uri.queryParameters['\$os'], anyOf('Android', 'iOS', 'Mac OS X'));
     });
 

--- a/packages/mixpanel_flutter_session_replay/test/upload_service_test.dart
+++ b/packages/mixpanel_flutter_session_replay/test/upload_service_test.dart
@@ -10,6 +10,7 @@ import 'package:mixpanel_flutter_session_replay/src/internal/upload/upload_servi
 import 'package:mixpanel_flutter_session_replay/src/internal/upload/payload_serializer.dart';
 import 'package:mixpanel_flutter_session_replay/src/internal/settings/settings_service.dart';
 import 'package:mixpanel_flutter_session_replay/src/internal/logger.dart';
+import 'package:mixpanel_flutter_session_replay/src/version.dart';
 import 'package:mixpanel_flutter_session_replay/src/models/configuration.dart';
 import 'package:mixpanel_flutter_session_replay/src/models/session.dart';
 import 'package:mixpanel_flutter_session_replay/src/models/session_event.dart';
@@ -687,7 +688,7 @@ void main() {
         expect(params['distinct_id'], testDistinctId);
         expect(params['seq'], '0');
         expect(params['replay_id'], testSessionId);
-        expect(params['\$lib_version'], endsWith('-flutter'));
+        expect(params['\$lib_version'], sdkVersion);
         expect(params['\$os'], anyOf('Android', 'iOS', 'Mac OS X'));
       });
 


### PR DESCRIPTION
## Summary

- Change `sdkVersion` in [version.dart](packages/mixpanel_flutter_session_replay/lib/src/version.dart) from `"1.0.0-flutter"` to `"1.0.0"`
- Update three tests that asserted `endsWith('-flutter')` to compare directly against the `sdkVersion` constant

## Why

The `-flutter` suffix on `$lib_version` was unique to this package. Every other Mixpanel session-replay SDK (and the Flutter analytics SDK) sends a bare semver in `$lib_version` and puts the library identifier in `mp_lib`:

| SDK | `$lib_version` | `mp_lib` |
|---|---|---|
| Android SR | `1.4.0` | `android-sr` |
| iOS SR | `1.5.1` | `swift-sr` |
| React Native SR | `1.2.0` | `react-native-sr` |
| Flutter analytics | `2.4.4` | `flutter` |
| Flutter SR (before) | `1.0.0-flutter` | `flutter-sr` |
| Flutter SR (after) | `1.0.0` | `flutter-sr` |

Session replay was already sending `mp_lib: "flutter-sr"` ([settings_service.dart:127](packages/mixpanel_flutter_session_replay/lib/src/internal/settings/settings_service.dart#L127), [payload_serializer.dart:107](packages/mixpanel_flutter_session_replay/lib/src/internal/upload/payload_serializer.dart#L107)), so the suffix was duplicative.

It also blocked the release workflow's `version_files` check, which requires the semver in `version.dart` to exactly match the pubspec version — the check's own comment explicitly cites the `-flutter` leftover as the case it was designed to catch ([release-pub-dev.yml:109-110](.github/workflows/release-pub-dev.yml#L109-L110)). See the failing run: https://github.com/mixpanel/mixpanel-flutter/actions/runs/27980799291/job/82810416935

## Test plan

- [x] `dart analyze --fatal-infos` clean
- [x] `flutter test` — all 436 tests pass
- [x] `dart format --language-version=latest` clean
- [ ] After merge: re-tag `session-replay-v1.0.0` on the new main commit and confirm the workflow's `version_files` step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)