### PR TITLE
feat(analytics): Added support to return the fallback reason for the feature flag varient 

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -258,7 +258,7 @@ jobs:
           arch: ${{ matrix.arch }}
           profile: ${{ matrix.profile }}
           force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on -memory 3072 -partition-size 4096
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
       - name: Run integration tests on Android
@@ -269,7 +269,7 @@ jobs:
           arch: ${{ matrix.arch }}
           profile: ${{ matrix.profile }}
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on -memory 3072 -partition-size 4096
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on
           disable-animations: true
           working-directory: packages/mixpanel_flutter_session_replay/example
           script: |

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -258,7 +258,7 @@ jobs:
           arch: ${{ matrix.arch }}
           profile: ${{ matrix.profile }}
           force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on -memory 3072 -partition-size 4096
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
       - name: Run integration tests on Android
@@ -269,7 +269,7 @@ jobs:
           arch: ${{ matrix.arch }}
           profile: ${{ matrix.profile }}
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -accel on -memory 3072 -partition-size 4096
           disable-animations: true
           working-directory: packages/mixpanel_flutter_session_replay/example
           script: |

--- a/packages/mixpanel_flutter/android/build.gradle
+++ b/packages/mixpanel_flutter/android/build.gradle
@@ -66,8 +66,8 @@ android {
 }
 
 dependencies {
-    implementation "com.mixpanel.android:mixpanel-android:8.7.0"
-    // mixpanel-android:8.7.0 only declares mixpanel-android-common as a
+    implementation "com.mixpanel.android:mixpanel-android:8.9.0"
+    // mixpanel-android:8.9.0 only declares mixpanel-android-common as a
     // runtime dependency, so MixpanelEventBridge is not on the compile
     // classpath unless we add it explicitly here. EventBridgeSubscriber.kt
     // imports it directly.

--- a/packages/mixpanel_flutter/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
+++ b/packages/mixpanel_flutter/android/src/main/java/com/mixpanel/mixpanel_flutter/MixpanelFlutterPlugin.java
@@ -779,10 +779,31 @@ public class MixpanelFlutterPlugin implements FlutterPlugin, MethodCallHandler {
             map.put("persistedAtMillis", ((MixpanelFlagVariant.Source.Persistence) source).persistedAtMillis);
         } else if (source instanceof MixpanelFlagVariant.Source.Network) {
             map.put("kind", "network");
-        } else {
+        } else if (source instanceof MixpanelFlagVariant.Source.Fallback) {
             map.put("kind", "fallback");
+            map.put("reason", fallbackReasonToString(((MixpanelFlagVariant.Source.Fallback) source).reason));
+        } else {
+            // Defensive fallback for unknown source types
+            map.put("kind", "fallback");
+            map.put("reason", "flagNotFound");
         }
         return map;
+    }
+
+    private String fallbackReasonToString(MixpanelFlagVariant.Source.Fallback.Reason reason) {
+        if (reason == null) {
+            return "flagNotFound"; // safe default
+        }
+        switch (reason) {
+            case NOT_READY:
+                return "notReady";
+            case FLAG_NOT_FOUND:
+                return "flagNotFound";
+            case BACKEND_ERROR:
+                return "backendError";
+            default:
+                return "flagNotFound";
+        }
     }
 
     private VariantLookupPolicy parseVariantLookupPolicy(Map<String, Object> policyMap) {

--- a/packages/mixpanel_flutter/example/lib/feature_flags.dart
+++ b/packages/mixpanel_flutter/example/lib/feature_flags.dart
@@ -13,10 +13,27 @@ class _FeatureFlagsScreenState extends State<FeatureFlagsScreen> {
   late final Mixpanel _mixpanel;
   late final FeatureFlags _flags;
 
+  // Text controllers for flag name inputs
+  final _boolFlagController = TextEditingController(text: 'sample-bool-flag');
+  final _variantValueController = TextEditingController(text: 'sample-flag');
+  final _fullVariantController =
+      TextEditingController(text: 'ww_advanced_experiments_qa_2');
+  final _fallbackTestController =
+      TextEditingController(text: 'non-existent-flag-12345');
+
   @override
   void initState() {
     super.initState();
     _initMixpanel();
+  }
+
+  @override
+  void dispose() {
+    _boolFlagController.dispose();
+    _variantValueController.dispose();
+    _fullVariantController.dispose();
+    _fallbackTestController.dispose();
+    super.dispose();
   }
 
   Future<void> _initMixpanel() async {
@@ -34,7 +51,7 @@ class _FeatureFlagsScreenState extends State<FeatureFlagsScreen> {
               ),
               actions: [
                 TextButton(
-                  child: Text("OK"),
+                  child: const Text("OK"),
                   onPressed: () {
                     Navigator.of(context).pop();
                   },
@@ -48,19 +65,44 @@ class _FeatureFlagsScreenState extends State<FeatureFlagsScreen> {
     return '$label:\n  Expected: $expected\n  Actual: $actual  $match';
   }
 
+  Widget _buildFlagInput(String label, TextEditingController controller) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(fontSize: 12, color: Colors.grey),
+          ),
+          const SizedBox(height: 4),
+          TextField(
+            controller: controller,
+            decoration: InputDecoration(
+              contentPadding:
+                  const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+              hintText: 'Enter flag name',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Color(0xff4f44e0),
-        title: Text("Feature Flags"),
+        backgroundColor: const Color(0xff4f44e0),
+        title: const Text("Feature Flags"),
       ),
       body: Center(
           child: ListView(
         children: [
-          SizedBox(
-            height: 40,
-          ),
+          const SizedBox(height: 40),
           SizedBox(
             width: MediaQuery.of(context).size.width * 0.65,
             child: MixpanelButton(
@@ -71,91 +113,155 @@ class _FeatureFlagsScreenState extends State<FeatureFlagsScreen> {
               },
             ),
           ),
-          SizedBox(
-            height: 20,
+          const SizedBox(height: 30),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 40),
+            child: Divider(),
           ),
+          const SizedBox(height: 10),
+          _buildFlagInput('Test Fallback Flag Name:', _fallbackTestController),
+          const SizedBox(height: 10),
+          SizedBox(
+            width: MediaQuery.of(context).size.width * 0.65,
+            child: MixpanelButton(
+              text: 'Test Fallback Reasons',
+              onPressed: () async {
+                final flagName = _fallbackTestController.text.trim();
+                if (flagName.isEmpty) {
+                  _showAlert(context, "Error", "Please enter a flag name");
+                  return;
+                }
+
+                final fallback =
+                    MixpanelFlagVariant.fallback(flagName, 'default-value');
+                final variant = await _flags.getVariant(flagName, fallback);
+
+                final src = variant.source;
+                String reasonDetails = '';
+
+                if (src is FallbackSource) {
+                  reasonDetails =
+                      '''Fallback Reason: ${(src.reason)}''';
+                } else if (src is NetworkSource) {
+                  reasonDetails = 'Flag was loaded from network successfully';
+                } else if (src is PersistenceSource) {
+                  reasonDetails =
+                      'Flag was loaded from local cache (persisted at: ${src.persistedAt})';
+                }
+
+                final alertText = '''Flag: $flagName
+Value: ${variant.value}
+Source: ${src.runtimeType}
+
+$reasonDetails''';
+
+                _showAlert(context, "Fallback Reason Demo", alertText);
+              },
+            ),
+          ),
+          const SizedBox(height: 30),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 40),
+            child: Divider(),
+          ),
+          const SizedBox(height: 10),
+          _buildFlagInput('Boolean Flag Name:', _boolFlagController),
+          const SizedBox(height: 10),
           SizedBox(
             width: MediaQuery.of(context).size.width * 0.65,
             child: MixpanelButton(
               text: 'Get Boolean Flag (isEnabled)',
               onPressed: () async {
+                final flagName = _boolFlagController.text.trim();
+                if (flagName.isEmpty) {
+                  _showAlert(context, "Error", "Please enter a flag name");
+                  return;
+                }
+
                 const expected = true;
-                final actual = await _flags.isEnabled('sample-bool-flag', false);
-                _showAlert(
-                    context,
-                    "Boolean Flag: sample-bool-flag",
+                final actual = await _flags.isEnabled(flagName, false);
+                _showAlert(context, "Boolean Flag: $flagName",
                     _formatComparison('isEnabled', expected, actual));
               },
             ),
           ),
-          SizedBox(
-            height: 20,
+          const SizedBox(height: 30),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 40),
+            child: Divider(),
           ),
+          const SizedBox(height: 10),
+          _buildFlagInput('Variant Value Flag Name:', _variantValueController),
+          const SizedBox(height: 10),
           SizedBox(
             width: MediaQuery.of(context).size.width * 0.65,
             child: MixpanelButton(
               text: 'Get Variant Value',
               onPressed: () async {
+                final flagName = _variantValueController.text.trim();
+                if (flagName.isEmpty) {
+                  _showAlert(context, "Error", "Please enter a flag name");
+                  return;
+                }
+
                 const expected = 'test';
-                final actual =
-                    await _flags.getVariantValue('sample-flag', 'fallback');
-                _showAlert(
-                    context,
-                    "Variant Value: sample-flag",
+                final actual = await _flags.getVariantValue(flagName, 'fallback');
+                _showAlert(context, "Variant Value: $flagName",
                     _formatComparison('getVariantValue', expected, actual));
               },
             ),
           ),
-          SizedBox(
-            height: 20,
+          const SizedBox(height: 30),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 40),
+            child: Divider(),
           ),
+          const SizedBox(height: 10),
+          _buildFlagInput('Full Variant Flag Name:', _fullVariantController),
+          const SizedBox(height: 10),
           SizedBox(
             width: MediaQuery.of(context).size.width * 0.65,
             child: MixpanelButton(
               text: 'Get Full Variant',
               onPressed: () async {
-                const flagName = 'ww_advanced_experiments_qa_2';
-                const expectedKey = 'treatment';
-                const expectedExperimentId =
-                    'e6f697b4-2f23-4e9d-b772-49dd9103733c';
-                const expectedIsExperimentActive = true;
-                final fallback =
-                    MixpanelFlagVariant.fallback(flagName, 'control');
+                final flagName = _fullVariantController.text.trim();
+                if (flagName.isEmpty) {
+                  _showAlert(context, "Error", "Please enter a flag name");
+                  return;
+                }
+
+                final fallback = MixpanelFlagVariant.fallback(flagName, 'control');
                 final variant = await _flags.getVariant(flagName, fallback);
-                final keyMatch = variant.key == expectedKey ? '✓' : '✗';
-                final expIdMatch =
-                    variant.experimentId == expectedExperimentId ? '✓' : '✗';
-                final activeMatch =
-                    variant.isExperimentActive == expectedIsExperimentActive
-                        ? '✓'
-                        : '✗';
+
                 final src = variant.source;
                 final sourceLabel = src is PersistenceSource
                     ? 'persistence (persistedAt: ${src.persistedAt})'
                     : src is NetworkSource
                         ? 'network'
                         : src is FallbackSource
-                            ? 'fallback'
+                            ? 'fallback (reason: ${(src.reason)})'
                             : 'unknown';
-                final alertText = '''Expected:
-  key: $expectedKey
-  experimentId: $expectedExperimentId
-  isExperimentActive: $expectedIsExperimentActive
 
-Actual:
-  key: ${variant.key}  $keyMatch
+                final alertText = '''Flag: $flagName
+
+Details:
+  key: ${variant.key}
   value: ${variant.value}
-  experimentId: ${variant.experimentId}  $expIdMatch
-  isExperimentActive: ${variant.isExperimentActive}  $activeMatch
-  isQaTester: ${variant.isQaTester}
+  experimentId: ${variant.experimentId ?? 'null'}
+  isExperimentActive: ${variant.isExperimentActive ?? 'null'}
+  isQaTester: ${variant.isQaTester ?? 'null'}
   source: $sourceLabel''';
+
                 _showAlert(context, "Full Variant: $flagName", alertText);
               },
             ),
           ),
-          SizedBox(
-            height: 20,
+          const SizedBox(height: 30),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 40),
+            child: Divider(),
           ),
+          const SizedBox(height: 10),
           SizedBox(
             width: MediaQuery.of(context).size.width * 0.65,
             child: MixpanelButton(
@@ -170,23 +276,19 @@ Actual:
               },
             ),
           ),
-          SizedBox(
-            height: 20,
-          ),
+          const SizedBox(height: 20),
           SizedBox(
             width: MediaQuery.of(context).size.width * 0.65,
             child: MixpanelButton(
               text: 'Load Flags',
               onPressed: () async {
                 await _flags.loadFlags();
-                _showAlert(context, "Load Flags",
-                    "Flags reload triggered successfully");
+                _showAlert(
+                    context, "Load Flags", "Flags reload triggered successfully");
               },
             ),
           ),
-          SizedBox(
-            height: 40,
-          ),
+          const SizedBox(height: 40),
         ],
       )),
     );

--- a/packages/mixpanel_flutter/ios/mixpanel_flutter.podspec
+++ b/packages/mixpanel_flutter/ios/mixpanel_flutter.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'mixpanel_flutter/Sources/mixpanel_flutter/**/*.swift'
   s.dependency 'Flutter'
-  s.dependency 'Mixpanel-swift', '6.4.1'
+  s.dependency 'Mixpanel-swift', '6.5.1'
   # Explicit dependency (also pulled in transitively by Mixpanel-swift 6.4+)
   # so `import MixpanelSwiftCommon` in our plugin resolves reliably.
   s.dependency 'MixpanelSwiftCommon', '~> 1.0.1'

--- a/packages/mixpanel_flutter/ios/mixpanel_flutter/Package.swift
+++ b/packages/mixpanel_flutter/ios/mixpanel_flutter/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/mixpanel/mixpanel-swift.git",
-            exact: "6.4.1"
+            exact: "6.5.1"
         ),
         .package(name: "FlutterFramework", path: "../FlutterFramework")
     ],

--- a/packages/mixpanel_flutter/lib/mixpanel_flutter.dart
+++ b/packages/mixpanel_flutter/lib/mixpanel_flutter.dart
@@ -8,6 +8,19 @@ import 'package:mixpanel_flutter/codec/mixpanel_message_codec.dart';
 import 'package:mixpanel_flutter/src/version.dart';
 import 'package:mixpanel_flutter_common/mixpanel_flutter_common.dart';
 
+/// Describes why the SDK returned a fallback variant.
+///
+/// - [FallbackReason.notReady]: Flags haven't finished loading yet.
+/// - [FallbackReason.flagNotFound]: The requested flag key is absent from
+///   loaded data.
+/// - [FallbackReason.backendError]: Network fetch failed with no cached or
+///   persisted flags available.
+enum FallbackReason {
+  notReady,
+  flagNotFound,
+  backendError,
+}
+
 /// Identifies where a served [MixpanelFlagVariant] came from. Non-null on
 /// every variant the SDK returns:
 /// - [NetworkSource]: the variant was assigned by the most recent successful
@@ -16,9 +29,10 @@ import 'package:mixpanel_flutter_common/mixpanel_flutter_common.dart';
 ///   layer; [PersistenceSource.persistedAt] is when the variant set was
 ///   originally written.
 /// - [FallbackSource]: the SDK could not produce a real variant and returned
-///   the developer-supplied fallback unchanged. Variants the developer
-///   constructs directly also default to this source, since the only reason
-///   to build one is to pass it as a fallback.
+///   the developer-supplied fallback unchanged. [FallbackSource.reason]
+///   indicates why (not ready, flag not found, or backend error). Variants
+///   the developer constructs directly also default to this source, since the
+///   only reason to build one is to pass it as a fallback.
 ///
 /// The persistence timestamp lives only on [PersistenceSource] so invalid
 /// combinations like "network with a timestamp" are unrepresentable.
@@ -28,7 +42,8 @@ abstract class MixpanelFlagVariantSource {
   const factory MixpanelFlagVariantSource.network() = NetworkSource;
   factory MixpanelFlagVariantSource.persistence(
       {required DateTime persistedAt}) = PersistenceSource;
-  const factory MixpanelFlagVariantSource.fallback() = FallbackSource;
+  const factory MixpanelFlagVariantSource.fallback(
+      {FallbackReason reason}) = FallbackSource;
 
   /// Decodes a source map produced by the platform handlers. Falls back to
   /// [FallbackSource] for missing, malformed, or unrecognized payloads.
@@ -36,7 +51,10 @@ abstract class MixpanelFlagVariantSource {
     if (map == null) return const FallbackSource();
     final kind = map['kind'];
     if (kind == 'network') return const NetworkSource();
-    if (kind == 'fallback') return const FallbackSource();
+    if (kind == 'fallback') {
+      final reasonStr = map['reason'] as String?;
+      return FallbackSource(reason: _parseFallbackReason(reasonStr));
+    }
     if (kind == 'persistence') {
       final raw = map['persistedAtMillis'];
       final millis = raw is int ? raw : (raw is num ? raw.toInt() : null);
@@ -50,6 +68,22 @@ abstract class MixpanelFlagVariantSource {
           persistedAt: DateTime.fromMillisecondsSinceEpoch(millis));
     }
     return const FallbackSource();
+  }
+
+  /// Parses a fallback reason string from the platform handlers.
+  /// Returns [FallbackReason.flagNotFound] as a safe default for
+  /// unrecognized or missing values.
+  static FallbackReason _parseFallbackReason(String? reasonStr) {
+    switch (reasonStr) {
+      case 'notReady':
+        return FallbackReason.notReady;
+      case 'flagNotFound':
+        return FallbackReason.flagNotFound;
+      case 'backendError':
+        return FallbackReason.backendError;
+      default:
+        return FallbackReason.flagNotFound;
+    }
   }
 }
 
@@ -87,16 +121,20 @@ class PersistenceSource extends MixpanelFlagVariantSource {
 
 /// The SDK returned the developer-supplied fallback unchanged.
 class FallbackSource extends MixpanelFlagVariantSource {
-  const FallbackSource();
+  /// Why the SDK returned the fallback instead of a real variant.
+  final FallbackReason reason;
+
+  const FallbackSource({this.reason = FallbackReason.flagNotFound});
 
   @override
-  String toString() => 'FallbackSource()';
+  String toString() => 'FallbackSource(reason: $reason)';
 
   @override
-  bool operator ==(Object other) => other is FallbackSource;
+  bool operator ==(Object other) =>
+      other is FallbackSource && other.reason == reason;
 
   @override
-  int get hashCode => 0xfa11; // arbitrary stable constant for the singleton-ish case
+  int get hashCode => reason.hashCode;
 }
 
 /// Represents a feature flag variant with metadata.

--- a/packages/mixpanel_flutter/macos/mixpanel_flutter.podspec
+++ b/packages/mixpanel_flutter/macos/mixpanel_flutter.podspec
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'mixpanel_flutter/Sources/mixpanel_flutter/**/*.swift'
   s.dependency 'FlutterMacOS'
-  s.dependency 'Mixpanel-swift', '6.4.1'
-  # Explicit dependency (also pulled in transitively by Mixpanel-swift 6.4+)
+  s.dependency 'Mixpanel-swift', '6.5.1'
+  # Explicit dependency (also pulled in transitively by Mixpanel-swift 6.5+)
   # so `import MixpanelSwiftCommon` in our plugin resolves reliably.
   s.dependency 'MixpanelSwiftCommon', '~> 1.0.1'
   s.platform = :osx, '10.15'

--- a/packages/mixpanel_flutter/macos/mixpanel_flutter/Package.swift
+++ b/packages/mixpanel_flutter/macos/mixpanel_flutter/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/mixpanel/mixpanel-swift.git",
-            exact: "6.4.1"
+            exact: "6.5.1"
         ),
         .package(name: "FlutterFramework", path: "../FlutterFramework")
     ],

--- a/packages/mixpanel_flutter/swift/Classes/SwiftMixpanelFlutterPlugin.swift
+++ b/packages/mixpanel_flutter/swift/Classes/SwiftMixpanelFlutterPlugin.swift
@@ -796,8 +796,22 @@ public class SwiftMixpanelFlutterPlugin: NSObject, FlutterPlugin {
                 "kind": "persistence",
                 "persistedAtMillis": Int64(persistedAt.timeIntervalSince1970 * 1000)
             ]
-        case .fallback:
-            return ["kind": "fallback"]
+        case .fallback(let reason):
+            return [
+                "kind": "fallback",
+                "reason": fallbackReasonToString(reason)
+            ]
+        }
+    }
+
+    private func fallbackReasonToString(_ reason: MixpanelFlagVariant.FallbackReason) -> String {
+        switch reason {
+        case .notReady:
+            return "notReady"
+        case .flagNotFound:
+            return "flagNotFound"
+        case .backendError:
+            return "backendError"
         }
     }
 

--- a/packages/mixpanel_flutter/test/mixpanel_flutter_test.dart
+++ b/packages/mixpanel_flutter/test/mixpanel_flutter_test.dart
@@ -1547,6 +1547,74 @@ void main() {
       expect(const FallbackSource(), const FallbackSource());
     });
 
+    test('FallbackSource with same reason are equal', () {
+      expect(
+          const FallbackSource(reason: FallbackReason.notReady),
+          const FallbackSource(reason: FallbackReason.notReady));
+    });
+
+    test('FallbackSource with different reasons are not equal', () {
+      expect(
+          const FallbackSource(reason: FallbackReason.notReady),
+          isNot(const FallbackSource(reason: FallbackReason.flagNotFound)));
+    });
+
+    test('FallbackSource defaults to flagNotFound reason', () {
+      const source = FallbackSource();
+      expect(source.reason, FallbackReason.flagNotFound);
+    });
+
+    test('MixpanelFlagVariant.fromMap parses fallback reason', () {
+      final variant = MixpanelFlagVariant.fromMap({
+        'key': 'flag_a',
+        'value': 'on',
+        'source': {'kind': 'fallback', 'reason': 'notReady'},
+      });
+      expect(variant.source, isA<FallbackSource>());
+      expect((variant.source as FallbackSource).reason,
+          FallbackReason.notReady);
+    });
+
+    test('MixpanelFlagVariant.fromMap handles all fallback reasons', () {
+      final reasons = {
+        'notReady': FallbackReason.notReady,
+        'flagNotFound': FallbackReason.flagNotFound,
+        'backendError': FallbackReason.backendError,
+      };
+
+      reasons.forEach((reasonStr, expectedReason) {
+        final variant = MixpanelFlagVariant.fromMap({
+          'key': 'flag_a',
+          'value': 'on',
+          'source': {'kind': 'fallback', 'reason': reasonStr},
+        });
+        expect((variant.source as FallbackSource).reason, expectedReason);
+      });
+    });
+
+    test(
+        'MixpanelFlagVariant.fromMap defaults to flagNotFound for unknown reason',
+        () {
+      final variant = MixpanelFlagVariant.fromMap({
+        'key': 'flag_a',
+        'value': 'on',
+        'source': {'kind': 'fallback', 'reason': 'unknownReason'},
+      });
+      expect((variant.source as FallbackSource).reason,
+          FallbackReason.flagNotFound);
+    });
+
+    test('MixpanelFlagVariant.fromMap defaults to flagNotFound when reason missing',
+        () {
+      final variant = MixpanelFlagVariant.fromMap({
+        'key': 'flag_a',
+        'value': 'on',
+        'source': {'kind': 'fallback'},
+      });
+      expect((variant.source as FallbackSource).reason,
+          FallbackReason.flagNotFound);
+    });
+
     test('PersistenceSource equality uses persistedAt', () {
       final t = DateTime.fromMillisecondsSinceEpoch(1700000000000);
       expect(PersistenceSource(persistedAt: t),

--- a/packages/mixpanel_flutter_session_replay/example/pubspec_overrides.yaml
+++ b/packages/mixpanel_flutter_session_replay/example/pubspec_overrides.yaml
@@ -1,0 +1,8 @@
+# This file overrides dependencies to use local packages during development and CI.
+# It ensures the session replay example uses the local analytics package with the
+# latest native SDK versions rather than the published version from pub.dev.
+dependency_overrides:
+  mixpanel_flutter:
+    path: ../../mixpanel_flutter
+  mixpanel_flutter_common:
+    path: ../../mixpanel_flutter_common

--- a/packages/mixpanel_flutter_session_replay/example/pubspec_overrides.yaml
+++ b/packages/mixpanel_flutter_session_replay/example/pubspec_overrides.yaml
@@ -1,8 +1,0 @@
-# This file overrides dependencies to use local packages during development and CI.
-# It ensures the session replay example uses the local analytics package with the
-# latest native SDK versions rather than the published version from pub.dev.
-dependency_overrides:
-  mixpanel_flutter:
-    path: ../../mixpanel_flutter
-  mixpanel_flutter_common:
-    path: ../../mixpanel_flutter_common


### PR DESCRIPTION

**Feature flag fallback reason support:**

* Added a `FallbackReason` enum and extended the `FallbackSource` class in Dart to include a `reason` field, allowing the SDK to specify why a fallback variant was returned (e.g., not ready, flag not found, backend error).
* Upgraded Mixpanel Android SDK from `8.7.0` to `8.9.0` in `build.gradle`.
* Upgraded Mixpanel Swift SDK from `6.4.1` to `6.5.1` in both CocoaPods and Swift Package Manager definitions
* Refactored the example Flutter app to allow dynamic input of flag names, added UI for testing fallback reasons, and improved the display of variant source details. 
* Configured explicit memory limits for the emulator
