### PR TITLE
chore: support AGP 9's built-in Kotlin

### DIFF
--- a/packages/mixpanel_flutter/android/build.gradle
+++ b/packages/mixpanel_flutter/android/build.gradle
@@ -25,8 +25,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+// android.builtInKotlin lets a project opt out of AGP 9's built-in Kotlin and fall back to the
+// standalone plugin, so it must be honored in addition to the AGP version.
+def builtInKotlin = agpMajor >= 9 && project.findProperty('android.builtInKotlin') != 'false'
 
-if (agpMajor < 9) {
+if (!builtInKotlin) {
     apply plugin: 'kotlin-android'
 }
 
@@ -48,18 +51,24 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    kotlin {
-        compilerOptions {
-            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-            // mixpanel-android-common:1.0.1 is published with Kotlin 2.0
-            // metadata. Flutter's gradle integration picks a KGP version we
-            // can't reliably control from this module's buildscript, so a
-            // Kotlin 1.9.x compiler often ends up compiling this plugin and
-            // chokes on the newer metadata. The bytecode itself is
-            // forward-compatible (the consumed APIs are just a Flow and a
-            // data class), so suppressing the metadata version check is the
-            // canonical workaround.
-            freeCompilerArgs.add('-Xskip-metadata-version-check')
+    // mixpanel-android-common:1.0.1 is published with Kotlin 2.0 metadata. Flutter's gradle
+    // integration picks a KGP version we can't reliably control from this module's buildscript,
+    // so a Kotlin 1.9.x compiler often ends up compiling this plugin and chokes on the newer
+    // metadata. The bytecode itself is forward-compatible (the consumed APIs are just a Flow and
+    // a data class), so suppressing the metadata version check is the canonical workaround.
+    if (builtInKotlin) {
+        // JvmTarget.JVM_17 needs KGP 1.8.0+; only safe here because AGP 9's built-in Kotlin
+        // doesn't use this module's own (older) pinned kotlin_version.
+        kotlin {
+            compilerOptions {
+                jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+                freeCompilerArgs.add('-Xskip-metadata-version-check')
+            }
+        }
+    } else {
+        kotlinOptions {
+            jvmTarget = '17'
+            freeCompilerArgs += ['-Xskip-metadata-version-check']
         }
     }
 

--- a/packages/mixpanel_flutter/android/build.gradle
+++ b/packages/mixpanel_flutter/android/build.gradle
@@ -23,7 +23,12 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     // Safely handle 'namespace' property for new Android Gradle plugin versions
@@ -43,17 +48,19 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = '17'
-        // mixpanel-android-common:1.0.1 is published with Kotlin 2.0
-        // metadata. Flutter's gradle integration picks a KGP version we
-        // can't reliably control from this module's buildscript, so a
-        // Kotlin 1.9.x compiler often ends up compiling this plugin and
-        // chokes on the newer metadata. The bytecode itself is
-        // forward-compatible (the consumed APIs are just a Flow and a
-        // data class), so suppressing the metadata version check is the
-        // canonical workaround.
-        freeCompilerArgs += ['-Xskip-metadata-version-check']
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+            // mixpanel-android-common:1.0.1 is published with Kotlin 2.0
+            // metadata. Flutter's gradle integration picks a KGP version we
+            // can't reliably control from this module's buildscript, so a
+            // Kotlin 1.9.x compiler often ends up compiling this plugin and
+            // chokes on the newer metadata. The bytecode itself is
+            // forward-compatible (the consumed APIs are just a Flow and a
+            // data class), so suppressing the metadata version check is the
+            // canonical workaround.
+            freeCompilerArgs.add('-Xskip-metadata-version-check')
+        }
     }
 
     sourceSets {

--- a/packages/mixpanel_flutter/android/build.gradle
+++ b/packages/mixpanel_flutter/android/build.gradle
@@ -51,24 +51,18 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    // mixpanel-android-common:1.0.1 is published with Kotlin 2.0 metadata. Flutter's gradle
-    // integration picks a KGP version we can't reliably control from this module's buildscript,
-    // so a Kotlin 1.9.x compiler often ends up compiling this plugin and chokes on the newer
-    // metadata. The bytecode itself is forward-compatible (the consumed APIs are just a Flow and
-    // a data class), so suppressing the metadata version check is the canonical workaround.
-    if (builtInKotlin) {
-        // JvmTarget.JVM_17 needs KGP 1.8.0+; only safe here because AGP 9's built-in Kotlin
-        // doesn't use this module's own (older) pinned kotlin_version.
-        kotlin {
-            compilerOptions {
-                jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-                freeCompilerArgs.add('-Xskip-metadata-version-check')
-            }
-        }
-    } else {
-        kotlinOptions {
-            jvmTarget = '17'
-            freeCompilerArgs += ['-Xskip-metadata-version-check']
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+            // mixpanel-android-common:1.0.1 is published with Kotlin 2.0
+            // metadata. Flutter's gradle integration picks a KGP version we
+            // can't reliably control from this module's buildscript, so a
+            // Kotlin 1.9.x compiler often ends up compiling this plugin and
+            // chokes on the newer metadata. The bytecode itself is
+            // forward-compatible (the consumed APIs are just a Flow and a
+            // data class), so suppressing the metadata version check is the
+            // canonical workaround.
+            freeCompilerArgs.add('-Xskip-metadata-version-check')
         }
     }
 


### PR DESCRIPTION
AGP 9 makes the `org.jetbrains.kotlin.android` plugin redundant and rejects it outright at build time:

```
Failed to apply plugin 'org.jetbrains.kotlin.android'
The 'org.jetbrains.kotlin.android' plugin is no longer required for Kotlin support since AGP 9.0.
```

This guards the plugin application behind an AGP-major-version check and moves `jvmTarget`/`freeCompilerArgs` to the `compilerOptions` DSL, which is understood both by the standalone `kotlin-android` plugin (AGP < 9) and by AGP 9's built-in Kotlin support ([reference](https://kotl.in/gradle/agp-built-in-kotlin)). Same pattern already shipped by `device_info_plus`, `package_info_plus` and `share_plus` for this exact migration.

Tested against a Flutter 3.47 / AGP 9.3.0 app — builds cleanly with this change, fails without it.

Fixes #260