### PR TITLE
feat(session-replay): send app bundle_id and build_number as settings API query params

### DIFF
--- a/packages/mixpanel_flutter_session_replay/android/src/main/kotlin/com/mixpanel/flutter_session_replay/MixpanelSessionReplayPlugin.kt
+++ b/packages/mixpanel_flutter_session_replay/android/src/main/kotlin/com/mixpanel/flutter_session_replay/MixpanelSessionReplayPlugin.kt
@@ -3,6 +3,7 @@ package com.mixpanel.flutter_session_replay
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
+import android.os.Build
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -59,8 +60,34 @@ class MixpanelSessionReplayPlugin : FlutterPlugin, MethodCallHandler {
             }
             "beginBackgroundTask" -> result.success(null)
             "endBackgroundTask" -> result.success(null)
+            "getAppInfo" -> getAppInfo(result)
             else -> result.notImplemented()
         }
+    }
+
+    // Host app identity for the settings request. Mirrors mixpanel-android:
+    // bundleId = package name, buildNumber = versionCode (longVersionCode on API 28+).
+    private fun getAppInfo(result: Result) {
+        val context = applicationContext
+        if (context == null) {
+            result.success(emptyMap<String, String>())
+            return
+        }
+
+        val info = mutableMapOf<String, String>()
+        try {
+            info["bundleId"] = context.packageName
+            val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+            info["buildNumber"] = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                packageInfo.longVersionCode.toString()
+            } else {
+                @Suppress("DEPRECATION")
+                packageInfo.versionCode.toString()
+            }
+        } catch (e: Exception) {
+            // Best-effort — omit whatever could not be resolved
+        }
+        result.success(info)
     }
 
     private fun registerSuperProperties(call: MethodCall) {

--- a/packages/mixpanel_flutter_session_replay/example/pubspec.yaml
+++ b/packages/mixpanel_flutter_session_replay/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: example
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.1.0
+version: 0.1.0+43
 
 environment:
   sdk: ^3.8.0

--- a/packages/mixpanel_flutter_session_replay/ios/mixpanel_flutter_session_replay/Sources/mixpanel_flutter_session_replay/MixpanelSessionReplayPlugin.swift
+++ b/packages/mixpanel_flutter_session_replay/ios/mixpanel_flutter_session_replay/Sources/mixpanel_flutter_session_replay/MixpanelSessionReplayPlugin.swift
@@ -40,9 +40,24 @@ public class MixpanelSessionReplayPlugin: NSObject, FlutterPlugin {
         case "endBackgroundTask":
             endBackgroundTask()
             result(nil)
+        case "getAppInfo":
+            result(appInfo())
         default:
             result(FlutterMethodNotImplemented)
         }
+    }
+
+    /// Host app identity for the settings request. Mirrors mixpanel-ios:
+    /// bundleId = bundle identifier, buildNumber = CFBundleVersion.
+    private func appInfo() -> [String: String] {
+        var info = [String: String]()
+        if let bundleId = Bundle.main.bundleIdentifier {
+            info["bundleId"] = bundleId
+        }
+        if let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
+            info["buildNumber"] = buildNumber
+        }
+        return info
     }
 
     private func beginBackgroundTask() {

--- a/packages/mixpanel_flutter_session_replay/lib/src/internal/app_info.dart
+++ b/packages/mixpanel_flutter_session_replay/lib/src/internal/app_info.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/services.dart';
+
+/// Host app identity, read from the platform via the native plugin.
+///
+/// Sent as query parameters on the `/settings` request so the Mixpanel backend
+/// can apply server-side SDK blocking per app ID and app build version.
+///
+/// `buildNumber` deliberately carries the platform's *build* identifier rather
+/// than the user-facing version string, matching the native SDKs:
+/// `CFBundleVersion` on iOS/macOS and `versionCode` on Android.
+class AppInfo {
+  static const _channel = MethodChannel('com.mixpanel.flutter_session_replay');
+
+  const AppInfo({this.bundleId, this.buildNumber});
+
+  /// The host app's bundle/package identifier, or null if unavailable.
+  final String? bundleId;
+
+  /// The host app's build number, or null if unavailable.
+  final String? buildNumber;
+
+  /// Reads the host app's bundle ID and build number from the platform.
+  ///
+  /// Returns an [AppInfo] with null fields when the values cannot be read —
+  /// for example on a platform without the plugin registered, as in unit
+  /// tests. Callers omit the corresponding query parameters in that case.
+  static Future<AppInfo> fromPlatform() async {
+    try {
+      final info = await _channel.invokeMapMethod<String, dynamic>(
+        'getAppInfo',
+      );
+      return AppInfo(
+        bundleId: info?['bundleId'] as String?,
+        buildNumber: info?['buildNumber'] as String?,
+      );
+    } catch (_) {
+      // Best-effort — the params are omitted when the platform can't supply them
+      return const AppInfo();
+    }
+  }
+}

--- a/packages/mixpanel_flutter_session_replay/lib/src/internal/settings/settings_service.dart
+++ b/packages/mixpanel_flutter_session_replay/lib/src/internal/settings/settings_service.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import '../../version.dart';
+import '../app_info.dart';
 import '../endpoints.dart';
 import '../logger.dart';
 import 'remote_settings_result.dart';
@@ -27,6 +28,14 @@ class SettingsService {
   final MixpanelLogger _logger;
   final http.Client _httpClient;
   final SettingsStorageProvider _storageProvider;
+
+  /// Explicit overrides for host app identity; when null the values are read
+  /// from the platform. Injected by tests.
+  final String? _bundleIdOverride;
+  final String? _buildNumberOverride;
+
+  /// Platform-resolved app info, fetched at most once per instance.
+  AppInfo? _appInfo;
 
   /// Full `/settings` endpoint, derived from the configured base URL.
   final String _endpoint;
@@ -57,11 +66,32 @@ class SettingsService {
     required SettingsStorageProvider storageProvider,
     required http.Client httpClient,
     String serverUrl = EndPoints.defaultBaseUrl,
+    String? bundleId,
+    String? buildNumber,
   }) : _token = token,
        _logger = logger,
        _httpClient = httpClient,
        _storageProvider = storageProvider,
+       _bundleIdOverride = bundleId,
+       _buildNumberOverride = buildNumber,
        _endpoint = EndPoints.settings(serverUrl);
+
+  /// Resolve host app identity, preferring injected overrides.
+  ///
+  /// Skips the platform channel entirely when both values are injected.
+  Future<AppInfo> _resolveAppInfo() async {
+    if (_bundleIdOverride != null && _buildNumberOverride != null) {
+      return AppInfo(
+        bundleId: _bundleIdOverride,
+        buildNumber: _buildNumberOverride,
+      );
+    }
+    final platform = _appInfo ??= await AppInfo.fromPlatform();
+    return AppInfo(
+      bundleId: _bundleIdOverride ?? platform.bundleId,
+      buildNumber: _buildNumberOverride ?? platform.buildNumber,
+    );
+  }
 
   /// Fetch remote settings including recording status and SDK config.
   ///
@@ -120,15 +150,28 @@ class SettingsService {
 
   /// Make network request to settings endpoint.
   Future<RemoteSettingsResult> _performRemoteSettingsFetch() async {
-    final uri = Uri.parse(_endpoint).replace(
-      queryParameters: {
-        'recording': '1',
-        'sdk_config': '1',
-        'mp_lib': 'flutter-sr',
-        '\$lib_version': sdkVersion,
-        '\$os': operatingSystem,
-      },
-    );
+    final appInfo = await _resolveAppInfo();
+
+    final queryParameters = <String, String>{
+      'recording': '1',
+      'sdk_config': '1',
+      'mp_lib': 'flutter-sr',
+      '\$lib_version': sdkVersion,
+      '\$os': operatingSystem,
+    };
+
+    // Include app bundle ID and build number to enable server-side SDK blocking
+    // per app ID and app build version
+    final bundleId = appInfo.bundleId;
+    if (bundleId != null) {
+      queryParameters['bundleId'] = bundleId;
+    }
+    final buildNumber = appInfo.buildNumber;
+    if (buildNumber != null) {
+      queryParameters['buildNumber'] = buildNumber;
+    }
+
+    final uri = Uri.parse(_endpoint).replace(queryParameters: queryParameters);
 
     final credentials = base64Encode(utf8.encode('$_token:'));
     final authHeader = 'Basic $credentials';

--- a/packages/mixpanel_flutter_session_replay/lib/src/internal/settings/settings_service.dart
+++ b/packages/mixpanel_flutter_session_replay/lib/src/internal/settings/settings_service.dart
@@ -164,11 +164,11 @@ class SettingsService {
     // per app ID and app build version
     final bundleId = appInfo.bundleId;
     if (bundleId != null) {
-      queryParameters['bundleId'] = bundleId;
+      queryParameters['bundle_id'] = bundleId;
     }
     final buildNumber = appInfo.buildNumber;
     if (buildNumber != null) {
-      queryParameters['buildNumber'] = buildNumber;
+      queryParameters['build_number'] = buildNumber;
     }
 
     final uri = Uri.parse(_endpoint).replace(queryParameters: queryParameters);

--- a/packages/mixpanel_flutter_session_replay/macos/mixpanel_flutter_session_replay/Sources/mixpanel_flutter_session_replay/MixpanelSessionReplayPlugin.swift
+++ b/packages/mixpanel_flutter_session_replay/macos/mixpanel_flutter_session_replay/Sources/mixpanel_flutter_session_replay/MixpanelSessionReplayPlugin.swift
@@ -27,9 +27,24 @@ public class MixpanelSessionReplayPlugin: NSObject, FlutterPlugin {
             result(nil)
         case "endBackgroundTask":
             result(nil)
+        case "getAppInfo":
+            result(appInfo())
         default:
             result(FlutterMethodNotImplemented)
         }
+    }
+
+    /// Host app identity for the settings request. Mirrors mixpanel-ios:
+    /// bundleId = bundle identifier, buildNumber = CFBundleVersion.
+    private func appInfo() -> [String: String] {
+        var info = [String: String]()
+        if let bundleId = Bundle.main.bundleIdentifier {
+            info["bundleId"] = bundleId
+        }
+        if let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
+            info["buildNumber"] = buildNumber
+        }
+        return info
     }
 
     private func compressImage(call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/packages/mixpanel_flutter_session_replay/test/settings_service_test.dart
+++ b/packages/mixpanel_flutter_session_replay/test/settings_service_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:http/http.dart' as http;
@@ -15,6 +16,8 @@ import 'package:mixpanel_flutter_session_replay/src/models/event_trigger.dart';
 import 'helpers/fake_http_client.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('SettingsService', () {
     final testToken = 'test-token-123';
     final testLogger = MixpanelLogger(LogLevel.none);
@@ -646,5 +649,135 @@ void main() {
         expect(uri.path, '/mp/settings');
       },
     );
+
+    group('app info query params', () {
+      const channel = MethodChannel('com.mixpanel.flutter_session_replay');
+
+      tearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null);
+      });
+
+      /// Stubs the native getAppInfo call with [response].
+      void stubAppInfo(Map<String, dynamic>? response) {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+              if (call.method == 'getAppInfo') return response;
+              return null;
+            });
+      }
+
+      test('sends injected bundleId and buildNumber', () async {
+        // GIVEN
+        final recorder = createRecordingHttpClient(
+          statusCode: 200,
+          body: jsonEncode({
+            'recording': {'is_enabled': true},
+          }),
+        );
+        final service = SettingsService(
+          storageProvider: storageProvider,
+          token: testToken,
+          logger: testLogger,
+          httpClient: recorder.client,
+          bundleId: 'com.test.app',
+          buildNumber: '1234',
+        );
+
+        // WHEN
+        await service.checkRecordingEnabled();
+
+        // THEN
+        final uri = recorder.requests.single.url;
+        expect(uri.queryParameters['bundleId'], 'com.test.app');
+        expect(uri.queryParameters['buildNumber'], '1234');
+
+        // Pre-existing params must be unaffected
+        expect(uri.queryParameters['recording'], '1');
+        expect(uri.queryParameters['sdk_config'], '1');
+        expect(uri.queryParameters['mp_lib'], 'flutter-sr');
+        expect(uri.queryParameters['\$lib_version'], sdkVersion);
+      });
+
+      test('resolves bundleId and buildNumber from the platform', () async {
+        // GIVEN
+        stubAppInfo({'bundleId': 'com.native.app', 'buildNumber': '99'});
+        final recorder = createRecordingHttpClient(
+          statusCode: 200,
+          body: jsonEncode({
+            'recording': {'is_enabled': true},
+          }),
+        );
+        final service = SettingsService(
+          storageProvider: storageProvider,
+          token: testToken,
+          logger: testLogger,
+          httpClient: recorder.client,
+        );
+
+        // WHEN
+        await service.checkRecordingEnabled();
+
+        // THEN
+        final uri = recorder.requests.single.url;
+        expect(uri.queryParameters['bundleId'], 'com.native.app');
+        expect(uri.queryParameters['buildNumber'], '99');
+      });
+
+      test('omits both params when the platform supplies neither', () async {
+        // GIVEN — no mock handler, so the channel throws MissingPluginException
+        final recorder = createRecordingHttpClient(
+          statusCode: 200,
+          body: jsonEncode({
+            'recording': {'is_enabled': true},
+          }),
+        );
+        final service = SettingsService(
+          storageProvider: storageProvider,
+          token: testToken,
+          logger: testLogger,
+          httpClient: recorder.client,
+        );
+
+        // WHEN
+        await service.checkRecordingEnabled();
+
+        // THEN
+        final uri = recorder.requests.single.url;
+        expect(uri.queryParameters.containsKey('bundleId'), isFalse);
+        expect(uri.queryParameters.containsKey('buildNumber'), isFalse);
+
+        // Pre-existing params must still be sent
+        expect(uri.queryParameters['recording'], '1');
+        expect(uri.queryParameters['sdk_config'], '1');
+        expect(uri.queryParameters['mp_lib'], 'flutter-sr');
+        expect(uri.queryParameters['\$lib_version'], sdkVersion);
+      });
+
+      test('omits only the param the platform cannot supply', () async {
+        // GIVEN — platform returns bundleId but no buildNumber
+        stubAppInfo({'bundleId': 'com.partial.app'});
+        final recorder = createRecordingHttpClient(
+          statusCode: 200,
+          body: jsonEncode({
+            'recording': {'is_enabled': true},
+          }),
+        );
+        final service = SettingsService(
+          storageProvider: storageProvider,
+          token: testToken,
+          logger: testLogger,
+          httpClient: recorder.client,
+        );
+
+        // WHEN
+        await service.checkRecordingEnabled();
+
+        // THEN
+        final uri = recorder.requests.single.url;
+        expect(uri.queryParameters['bundleId'], 'com.partial.app');
+        expect(uri.queryParameters.containsKey('buildNumber'), isFalse);
+      });
+    });
   });
 }

--- a/packages/mixpanel_flutter_session_replay/test/settings_service_test.dart
+++ b/packages/mixpanel_flutter_session_replay/test/settings_service_test.dart
@@ -689,8 +689,8 @@ void main() {
 
         // THEN
         final uri = recorder.requests.single.url;
-        expect(uri.queryParameters['bundleId'], 'com.test.app');
-        expect(uri.queryParameters['buildNumber'], '1234');
+        expect(uri.queryParameters['bundle_id'], 'com.test.app');
+        expect(uri.queryParameters['build_number'], '1234');
 
         // Pre-existing params must be unaffected
         expect(uri.queryParameters['recording'], '1');
@@ -720,8 +720,8 @@ void main() {
 
         // THEN
         final uri = recorder.requests.single.url;
-        expect(uri.queryParameters['bundleId'], 'com.native.app');
-        expect(uri.queryParameters['buildNumber'], '99');
+        expect(uri.queryParameters['bundle_id'], 'com.native.app');
+        expect(uri.queryParameters['build_number'], '99');
       });
 
       test('omits both params when the platform supplies neither', () async {
@@ -744,8 +744,8 @@ void main() {
 
         // THEN
         final uri = recorder.requests.single.url;
-        expect(uri.queryParameters.containsKey('bundleId'), isFalse);
-        expect(uri.queryParameters.containsKey('buildNumber'), isFalse);
+        expect(uri.queryParameters.containsKey('bundle_id'), isFalse);
+        expect(uri.queryParameters.containsKey('build_number'), isFalse);
 
         // Pre-existing params must still be sent
         expect(uri.queryParameters['recording'], '1');
@@ -775,8 +775,8 @@ void main() {
 
         // THEN
         final uri = recorder.requests.single.url;
-        expect(uri.queryParameters['bundleId'], 'com.partial.app');
-        expect(uri.queryParameters.containsKey('buildNumber'), isFalse);
+        expect(uri.queryParameters['bundle_id'], 'com.partial.app');
+        expect(uri.queryParameters.containsKey('build_number'), isFalse);
       });
     });
   });


### PR DESCRIPTION
This pull request enhances the Mixpanel Flutter Session Replay package by adding support for sending the host app's bundle/package identifier and build number as query parameters in the `/settings` request. This enables the Mixpanel backend to apply server-side SDK blocking per app ID and build version. The implementation includes platform-specific methods for retrieving app info, updates to the settings service to include these parameters, and comprehensive test coverage.

**Platform integration for app info retrieval:**

- Android: Added a `getAppInfo` method in `MixpanelSessionReplayPlugin.kt` to return the app's package name and build number (using `longVersionCode` or `versionCode` as appropriate). [[1]](diffhunk://#diff-80334bc798145db2274126e3b9799794f435d2c3edb8fa2beeacacd837b922ebR6) [[2]](diffhunk://#diff-80334bc798145db2274126e3b9799794f435d2c3edb8fa2beeacacd837b922ebR63-R92)
- iOS/macOS: Added a `getAppInfo` method in `MixpanelSessionReplayPlugin.swift` to return the bundle identifier and `CFBundleVersion`. [[1]](diffhunk://#diff-19dd26ef595b655fd6c07560bf9691f5368b5db37a76bfadff4ab4ef0432f946R43-R62) [[2]](diffhunk://#diff-55fcd1c530b3d594c14b8c06e9c034015a114efb66c512bd089bc1055aa29ae0R30-R49)

**Dart-side support and integration:**

- Introduced an `AppInfo` class in `app_info.dart` to abstract platform communication and expose bundle/build info to the Dart layer.
- Updated `SettingsService` to resolve app info (with override support for tests) and include `bundle_id` and `build_number` as query parameters in `/settings` requests. [[1]](diffhunk://#diff-badaa6395023d6b0e87be5a041a2e592c5de9b694557a3c0b9ddfdf45b0496cfR7) [[2]](diffhunk://#diff-badaa6395023d6b0e87be5a041a2e592c5de9b694557a3c0b9ddfdf45b0496cfR32-R39) [[3]](diffhunk://#diff-badaa6395023d6b0e87be5a041a2e592c5de9b694557a3c0b9ddfdf45b0496cfR69-R95) [[4]](diffhunk://#diff-badaa6395023d6b0e87be5a041a2e592c5de9b694557a3c0b9ddfdf45b0496cfL123-R174)

**Testing improvements:**

- Added comprehensive tests for app info query parameters, covering injected overrides, platform-supplied values, and fallback/omission scenarios. [[1]](diffhunk://#diff-72f416d87dbc333fd1f85051960d46b8c4a3862985b5609bdd6750c1d1aa2201R4) [[2]](diffhunk://#diff-72f416d87dbc333fd1f85051960d46b8c4a3862985b5609bdd6750c1d1aa2201R19-R20) [[3]](diffhunk://#diff-72f416d87dbc333fd1f85051960d46b8c4a3862985b5609bdd6750c1d1aa2201R652-R781)

**Other:**

- Updated example app version to reflect changes.

These changes ensure the plugin can provide necessary app identity information to the backend for advanced feature control and blocking, with robust cross-platform support and test coverage.## Summary

Flutter counterpart to the iOS and Android changes. Sends the host app's bundle
identifier and build number as query parameters on the `/settings` request, so the
backend can extend server-side SDK blocking to work **per app ID and per app build
version**.

Unlike React Native, this package does **not** wrap the native SDKs — it builds its own
settings request in Dart (`settings_service.dart`), so the change had to be implemented
here rather than inherited.

## What changed

Dart has no way to read host app metadata on its own, and the package had no
`package_info_plus` dependency. Rather than add a plugin dependency to a public SDK,
this extends the existing `com.mixpanel.flutter_session_replay` MethodChannel, which
already has plugins on all three platforms.

- **New `lib/src/internal/app_info.dart`** — `AppInfo.fromPlatform()` invokes a new
  `getAppInfo` channel method, returning null fields on any failure so the params are
  simply omitted.
- **`settings_service.dart`** — optional `bundleId` / `buildNumber` constructor params,
  resolved per-field against the platform via `_resolveAppInfo()`, which skips the
  channel entirely when both are injected. Params appended only when non-null.
- **Three native plugins** — `getAppInfo` added to each, deliberately mirroring the
  logic in the native SDKs so semantics match exactly:
  - Android: `applicationContext.packageName` + `lode` gated
    on API 28
  - iOS + macOS: `Bundle.main.bundleIdentifier` + `

No new pubspec dependency. All existing `SettingsSe unchanged.

## API URL
```
flutter ios
flutter: [FINE] mixpanel.session_replay: GET https://api.mixpanel.com/settings?recording=1&sdk_config=1&mp_lib=flutter-sr&%24lib_version=1.1.1&%24os=iOS&bundle_id=com.mixpanel.sessionreplay.flutter.example&build_number=43

flutter android 
2026-09-02 19:59:39.711 11834-11834 flutter                 com.example.example                  I  [FINE] mixpanel.session_replay: GET https://api.mixpanel.com/settings?recording=1&sdk_config=1&mp_lib=flutter-sr&%24lib_version=1.1.1&%24os=Android&bundle_id=com.example.example&build_number=43


```
## Test plan

- `flutter test` — **440 tests, all passing**
- `flutter analyze` — clean; `dart format` — clean
- Four new tests in `settings_service_test.dart`: ies resolved
  from a stubbed channel, both params omitted when the platform supplies nothing, and
  only the missing one omitted on a partial respons
- Native compile verification: `:mixpanel_flutter_session_replay:compileDebugKotlin`
  succeeds; example app builds successfully for **bor**,
  confirming both Swift plugins compile

Also adds `TestWidgetsFlutterBinding.ensureInitialized()` to
`settings_service_test.dart` — required by the chanwith four
other test files in the package.

Fixes SDK-153